### PR TITLE
fix pipe *-transcript cmdlet output -> null to prevent script output hashtable corruption

### DIFF
--- a/SetupApplications.ps1
+++ b/SetupApplications.ps1
@@ -143,7 +143,7 @@ $msGraphUserReadId = 'e1fe6dd8-ba31-4d61-89e7-88639da4683d'
 function main () {
     try {
         if ($logFile) {
-            Start-Transcript -path $logFile -Force
+            Start-Transcript -path $logFile -Force | Out-Null
         }
 
         enable-AAD
@@ -154,7 +154,7 @@ function main () {
     }
     finally {
         if ($logFile) {
-            Stop-Transcript
+            Stop-Transcript | Out-Null
         }
     }
 }

--- a/SetupUser.ps1
+++ b/SetupUser.ps1
@@ -130,7 +130,7 @@ $sleepSeconds = 5
 function main () {
     try {
         if ($logFile) {
-            Start-Transcript -path $logFile -Force
+            Start-Transcript -path $logFile -Force | Out-Null
         }
 
         enable-AADUser
@@ -141,7 +141,7 @@ function main () {
     }
     finally {
         if ($logFile) {
-            Stop-Transcript
+            Stop-Transcript | Out-Null
         }
     }
 }

--- a/UpdateApplication.ps1
+++ b/UpdateApplication.ps1
@@ -30,7 +30,7 @@ $global:ConfigObj = @{}
 function main () {
     try {
         if ($logFile) {
-            Start-Transcript -path $logFile -Force
+            Start-Transcript -path $logFile -Force | Out-Null
         }
 
         update-Application
@@ -41,7 +41,7 @@ function main () {
     }
     finally {
         if ($logFile) {
-            Stop-Transcript
+            Stop-Transcript | Out-Null
         }
     }
 }


### PR DESCRIPTION


## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...
fix pipe *-transcript cmdlet output -> null to prevent script output hashtable corruption
currently hashtable being returned as documented in learn documentation gets corrupted when running from a ascript
## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code
run as normal using learn documentation
```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->