### PR TITLE
add optional parameters for allowing Visual Studio clients access and passing custom MS Graph clientid and secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 ## service-fabric-aad-helpers Changelog
 
+### 23-11-12 231112
+
+- add support for Visual Studio client ids
+  .PARAMETER AddVisualStudioAccess
+  Used to add the Visual Studio MSAL client id's to the cluster application
+      https://learn.microsoft.com/en-us/azure/service-fabric/service-fabric-manage-application-in-visual-studio
+      Visual Studio 2022 and future versions: 04f0c124-f2bc-4f59-8241-bf6df9866bbd
+      Visual Studio 2019 and earlier: 872cd9fa-d31f-45e0-9eab-6e460a02d1f1
+
 ### 22-08-23 v2.0
+
 - add support for https://shell.azure.com
 - remove nuget requirement
 - migrate from ADAL to MSAL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## service-fabric-aad-helpers Changelog
 
+### 23-11-15 231115
+
+- add param() to common.ps1
+
+### 23-11-14 231114
+
+- exposing microsoft graph client id and grant type as parameters
+  - $MGClientID
+  - $MGClientSecret
+  - $MGGrantType
+
 ### 23-11-12 231112
 
 - add support for Visual Studio client ids

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,6 @@
   - $MGClientSecret
   - $MGGrantType
 
-### 23-11-12 231112
-
-- add support for Visual Studio client ids
-  .PARAMETER AddVisualStudioAccess
-  Used to add the Visual Studio MSAL client id's to the cluster application
-      https://learn.microsoft.com/en-us/azure/service-fabric/service-fabric-manage-application-in-visual-studio
-      Visual Studio 2022 and future versions: 04f0c124-f2bc-4f59-8241-bf6df9866bbd
-      Visual Studio 2019 and earlier: 872cd9fa-d31f-45e0-9eab-6e460a02d1f1
-
 ### 22-08-23 v2.0
 
 - add support for https://shell.azure.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@
   - $MGClientSecret
   - $MGGrantType
 
+### 23-11-12 231112
+
+- add support for Visual Studio client ids
+  .PARAMETER AddVisualStudioAccess
+  Used to add the Visual Studio MSAL client id's to the cluster application
+      https://learn.microsoft.com/en-us/azure/service-fabric/service-fabric-manage-application-in-visual-studio
+      Visual Studio 2022 and future versions: 04f0c124-f2bc-4f59-8241-bf6df9866bbd
+      Visual Studio 2019 and earlier: 872cd9fa-d31f-45e0-9eab-6e460a02d1f1
+
 ### 22-08-23 v2.0
 
 - add support for https://shell.azure.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
       https://learn.microsoft.com/en-us/azure/service-fabric/service-fabric-manage-application-in-visual-studio
       Visual Studio 2022 and future versions: 04f0c124-f2bc-4f59-8241-bf6df9866bbd
       Visual Studio 2019 and earlier: 872cd9fa-d31f-45e0-9eab-6e460a02d1f1
+  Resolves error: AADSTS65001: The user or administrator has not consented to use the application with ID '04f0c124-f2bc-4f59-8241-bf6df9866bbd' named 'Visual Studio'.
 
 ### 22-08-23 v2.0
 

--- a/Common.ps1
+++ b/Common.ps1
@@ -181,7 +181,6 @@ function get-RESTHeaders([guid]$tenantId,
         'ConsistencyLevel' = 'eventual'
     }
 
-    write-host "auth header: $($authHeader | convertto-json)"
     return $authHeader
 }
 

--- a/Common.ps1
+++ b/Common.ps1
@@ -303,7 +303,10 @@ function invoke-graphApiCall($uri, $headers = $global:ConfigObj.Headers, $body =
         $global:graphStatusCode = $result.StatusCode
 
         if (confirm-statusCodeSuccess -statusCode $global:graphStatusCode -method $method) {
-            return $resultObj
+            if ($resultObj) {
+                return $resultObj
+            }
+            return $true
         }
 
         return $null
@@ -398,4 +401,3 @@ function write-errorMessage($exceptionRecord) {
 }
 
 main -tenantId $TenantId -force:$force
-

--- a/Common.ps1
+++ b/Common.ps1
@@ -357,3 +357,13 @@ if ($ClusterName) {
     $WebApplicationName = $ClusterName + "_Cluster"
     $NativeClientApplicationName = $ClusterName + "_Client"
 }
+
+if (!$global:ConfigObj) {
+    $global:ConfigObj = @{
+        TenantId           = $TenantId
+        ClusterName        = $ClusterName
+        NativeClientAppId  = $null
+        ServicePrincipalId = $null
+        WebAppId           = $null
+    }
+}

--- a/Common.ps1
+++ b/Common.ps1
@@ -165,6 +165,7 @@ function get-RESTHeaders([guid]$tenantId,
     [string]$grantType = $MGGrantType, 
     [switch]$force
 ) {
+    write-host "get-RESTHeaders -tenantId $tenantId -clientId $clientId" -ForegroundColor Green
     $token = $null
     if (get-cloudInstance) {
         $token = get-RESTHeadersCloud
@@ -204,12 +205,13 @@ function get-RESTHeadersCloud($resourceUrl = $global:ConfigObj.ResourceUrl) {
 
 function get-RESTHeadersGraph([guid]$tenantId, [string]$authString, [guid]$clientId, [string]$clientSecret, [string]$grantType, [switch]$force) {
     assert-notNull -obj $tenantId -msg 'tenantId required'
+    write-host "get-RESTHeadersGraph -tenantId $tenantId -authString $authString -clientId $clientId -clientSecret *** -grantType $grantType -force:$force" -ForegroundColor Green
     # Use common client
     #$clientId = '14d82eec-204b-4c2f-b7e8-296a70dab67e' # well-known ps graph client id generated on connect
     #$grantType = 'urn:ietf:params:oauth:grant-type:device_code' #'client_credentials', #'authorization_code'
     $scope = 'user.read openid profile Application.ReadWrite.All User.ReadWrite.All Directory.ReadWrite.All Directory.Read.All Domain.Read.All AppRoleAssignment.ReadWrite.All'
     if (!$global:accessToken -or ($global:accessTokenExpiration -lt (get-date)) -or $force) {
-        $accessToken = get-RESTTokenGraph -tenantId $tenantId -grantType $grantType -clientId $clientId -scope $scope -uri $authString
+        $accessToken = get-RESTTokenGraph -tenantId $tenantId -grantType $grantType -clientId $clientId -clientSecret $clientSecret -scope $scope -uri $authString
     }
     return $accessToken
 }
@@ -217,7 +219,7 @@ function get-RESTHeadersGraph([guid]$tenantId, [string]$authString, [guid]$clien
 function get-RESTTokenGraph([guid]$tenantId, [string]$grantType, [guid]$clientId, [string]$clientSecret, [string]$scope, [string]$uri) {
     # requires app registration
     # will retry on device code until complete
-
+    write-host "get-RESTTokenGraph -tenantId $tenantId -grantType $grantType -clientId $clientId -clientSecret *** -scope $scope -uri $authString"
     write-host "token request" -ForegroundColor Green
     $global:logonResult = $null
     $error.clear()

--- a/Common.ps1
+++ b/Common.ps1
@@ -3,7 +3,7 @@
 Common script, do not call directly.
 
 .DESCRIPTION
-version: 2.0.3
+version: 231112
 
 #>
 

--- a/Common.ps1
+++ b/Common.ps1
@@ -7,12 +7,12 @@ version: 2.0.3
 
 #>
 
-function main () {
+function main ([guid]$tenantId = $null) {
     if ($headers) {
         return
     }
 
-    return get-RESTHeaders
+    return get-RESTHeaders -tenantId $tenantId
 }
 
 function assert-notNull($obj, $msg) {
@@ -74,7 +74,7 @@ function get-cloudInstance() {
     return $isCloudInstance
 }
 
-function get-restAuthGraph($tenantId, $clientId, $scope, $uri = 'https://login.microsoftonline.com') {
+function get-restAuthGraph([guid]$tenantId, [guid]$clientId, $scope, $uri = 'https://login.microsoftonline.com') {
     # authenticate to Graph using device code
 
     write-host "auth request" -ForegroundColor Green
@@ -103,14 +103,14 @@ function get-restAuthGraph($tenantId, $clientId, $scope, $uri = 'https://login.m
     return $global:authresult
 }
 
-function get-RESTHeaders() {
+function get-RESTHeaders([guid]$tenantId = $null) {
     $token = $null
     if (get-cloudInstance) {
         $token = get-RESTHeadersCloud
     }
     
     if (!$token) {
-        $token = get-RESTHeadersGraph -tenantId $TenantId
+        $token = get-RESTHeadersGraph -tenantId $tenantId
     }
     
     $authHeader = @{
@@ -141,7 +141,8 @@ function get-RESTHeadersCloud() {
     }
 }
 
-function get-RESTHeadersGraph($tenantId) {
+function get-RESTHeadersGraph([guid]$tenantId) {
+    assert-notNull -obj $tenantId -msg 'tenantId required'
     # Use common client 
     $clientId = '14d82eec-204b-4c2f-b7e8-296a70dab67e' # well-known ps graph client id generated on connect
     $grantType = 'urn:ietf:params:oauth:grant-type:device_code' #'client_credentials', #'authorization_code'
@@ -152,7 +153,7 @@ function get-RESTHeadersGraph($tenantId) {
     return $accessToken
 }
 
-function get-RESTTokenGraph($tenantId, $grantType, $clientId, $clientSecret, $scope, $uri = 'https://login.microsoftonline.com') {
+function get-RESTTokenGraph([guid]$tenantId, [string]$grantType, [guid]$clientId, [string]$clientSecret, [string]$scope, $uri = 'https://login.microsoftonline.com') {
     # requires app registration
     # will retry on device code until complete
 
@@ -350,7 +351,7 @@ switch ($Location) {
 
 $global:graphStatusCode = $null
 $sleepSeconds = 1
-$headers = main
+$headers = main -tenantId $TenantId
 $global:defaultHeaders = $headers
 
 if ($ClusterName) {

--- a/Examples.txt
+++ b/Examples.txt
@@ -1,6 +1,6 @@
-$Configobj = .\SetupApplications.ps1 -TenantId '80cd59e7-5f48-4325-8769-a47bc72de2d3' -ClusterName 'DemoLocalCluster' -WebApplicationReplyUrl 'https://localhost:19007/Explorer/index.html'
-.\SetupUser.ps1 -ConfigObj $Configobj -UserName 'DemoLocalUser' -Password 'Test1234'
-.\SetupUser.ps1 -ConfigObj $Configobj -UserName 'DemoLocalAdmin' -Password 'Test1234' -IsAdmin
+$ConfigObj = .\SetupApplications.ps1 -TenantId '80cd59e7-5f48-4325-8769-a47bc72de2d3' -ClusterName 'DemoLocalCluster' -WebApplicationReplyUrl 'https://localhost:19007/Explorer/index.html'
+.\SetupUser.ps1 -ConfigObj $ConfigObj -UserName 'DemoLocalUser' -Password 'Test1234'
+.\SetupUser.ps1 -ConfigObj $ConfigObj -UserName 'DemoLocalAdmin' -Password 'Test1234' -IsAdmin
 
 For China Mooncake:
-$Configobj = .\SetupApplications.ps1 -TenantId '80cd59e7-5f48-4325-8769-a47bc72de2d3' -ClusterName 'DemoLocalCluster' -WebApplicationReplyUrl 'https://localhost:19007/Explorer/index.html' -Location china
+$ConfigObj = .\SetupApplications.ps1 -TenantId '80cd59e7-5f48-4325-8769-a47bc72de2d3' -ClusterName 'DemoLocalCluster' -WebApplicationReplyUrl 'https://localhost:19007/Explorer/index.html' -Location china

--- a/Examples.txt
+++ b/Examples.txt
@@ -1,6 +1,0 @@
-$Configobj = .\SetupApplications.ps1 -TenantId '80cd59e7-5f48-4325-8769-a47bc72de2d3' -ClusterName 'DemoLocalCluster' -SpaApplicationReplyUrl 'https://localhost:19007/Explorer/index.html'
-.\SetupUser.ps1 -ConfigObj $ConfigObj -UserName 'DemoLocalUser' -Password 'Test1234'
-.\SetupUser.ps1 -ConfigObj $ConfigObj -UserName 'DemoLocalAdmin' -Password 'Test1234' -IsAdmin
-
-For China Mooncake:
-$ConfigObj = .\SetupApplications.ps1 -TenantId '80cd59e7-5f48-4325-8769-a47bc72de2d3' -ClusterName 'DemoLocalCluster' -SpaApplicationReplyUrl 'https://localhost:19007/Explorer/index.html' -Location china

--- a/README.md
+++ b/README.md
@@ -5,59 +5,142 @@ languages:
 products:
 - azure
 - azure-service-fabric
-description: "PowerShell scripts for setting up Azure Active Directory (Azure AD) to authenticate clients for a Service Fabric cluster (which must be done before creating the cluster)."
+description: "PowerShell scripts for setting up Azure Active Directory (Entra) to authenticate clients for a Service Fabric cluster (which must be done before creating the cluster)."
 urlFragment: service-fabric-aad-helpers
 ---
 
-# Service Fabric Azure AD helper scripts
+# Service Fabric Entra helper scripts
 
-PowerShell scripts for setting up Azure Active Directory (Azure AD) to authenticate clients for a Service Fabric cluster (which must be done *before* creating the cluster). Scripts can be re-executed as needed with same configuration if errors or timeouts occurred or additional users need to be configured.
+PowerShell scripts for setting up Azure Active Directory (AAD/Entra) to authenticate clients for a Service Fabric cluster (which must be done *before* creating the cluster). Scripts can be re-executed as needed with same configuration if errors or timeouts occurred or additional users need to be configured.
 
 ## Features
 
-This repo provides the following scripts for Azure AD:
+This repo provides the following scripts for Entra:
 
-* Create Azure AD applications (web, native) to control access to your Service Fabric cluster
-* Delete existing Azure AD applications (web, native) for controlling your cluster
-* Create a new Azure AD user
-* Delete an existing Azure AD user
+* Create Entra applications (web, native) to control access to your Service Fabric cluster
+* Delete existing Entra applications (web, native) for controlling your cluster
+* Create a new Entra user
+* Delete an existing Entra user
 
 ## Getting Started
 
 ### Prerequisites
 
-- [Azure Active Directory (Azure AD) tenant](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-create-new-tenant).
+* [Azure Active Directory (Entra) tenant](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-create-new-tenant).
 
 ## Usage
 
-### Create Azure AD applications
+### Create Entra applications
 
-Run **SetupApplications.ps1** to create two Azure AD applications (web and native applications) to control access to the cluster, storing the output into a variable to reuse when [creating Azure AD users](#create-azure-ad-users).
+Run **SetupApplications.ps1** to create two Entra applications (web and native applications) to control access to the cluster, storing the output into a variable to reuse when [creating Entra users](#create-entra-users).
 
-```PowerShell
-$ConfigObj = .\SetupApplications.ps1 -TenantId '<tenant_id>' -ClusterName '<cluster_name>' -SpaApplicationReplyUrl 'https://<cluster_domain>:19080/Explorer' -WebApplicationUri 'api://<tenant_id>/<cluster_name>' -AddResourceAccess
+```powershell
+$ConfigObj = .\SetupApplications.ps1 -TenantId '<tenant_id>' `
+  -ClusterName '<cluster_name>' `
+  -SpaApplicationReplyUrl 'https://<cluster_domain>:19080/Explorer' `
+  -WebApplicationUri 'api://<tenant_id>/<cluster_name>' `
+  -AddResourceAccess
 ```
 
-- **TenantId**: You can find this by executing the PowerShell command `Get-AzureSubscription`.
+### SetupApplications Parameters
 
-- **ClusterName**: This is used to prefix the Azure AD applications created by the script. It does not need to match the actual cluster name. It is provided to help you map Azure AD artifacts to their Service Fabric cluster.
+```powershell
+>help .\SetupApplications.ps1 -full    
+PARAMETERS
+    -TenantId <String>
+        ID of tenant hosting Service Fabric cluster.
+        
+    -WebApplicationName <String>
+        Name of web application representing Service Fabric cluster.
+        
+    -WebApplicationUri <String>
+        App ID URI of web application. If using https:// format, the domain has to be a verified domain. Format: https://<Domain name 
+        of cluster>
+        Example: 'https://mycluster.contoso.com'
+        Alternatively api:// format can be used which does not require a verified domain. Format: api://<tenant id>/<cluster name>
+        Example: 'api://4f812c74-978b-4b0e-acf5-06ffca635c0e/mycluster'
+        
+    -SpaApplicationReplyUrl <String>
+        Reply URL of spa application. Format: https://<Domain name of cluster>:<Service Fabric Http gateway port>
+        Example: 'https://mycluster.westus.cloudapp.azure.com:19080/Explorer/index.html'
 
-- **SpaApplicationReplyUrl**: The endpoint Azure AD returned to your users after signing in. Set this to the Service Fabric Explorer for your cluster, which by default is at *https://<cluster_domain>:19080/Explorer/index.html*
+    -NativeClientApplicationName <String>
+        Name of native client application representing client.
 
-- **WebApplicationUri**: Application ID URI of web application. If using https:// format, the domain has to be a verified domain. 
-Format: https://<Domain name of cluster>
-Example: 'https://mycluster.contoso.com'
-Alternatively api:// format can be used which does not require a verified domain. 
-Format: api://<tenant id>/<cluster name>
-Example: 'https://4f812c74-978b-4b0e-acf5-06ffca635c0e/mycluster'
+    -ClusterName <String>
+        A friendly Service Fabric cluster name. Application settings generated from cluster name: WebApplicationName = ClusterName +    
+        "_Cluster", NativeClientApplicationName = ClusterName + "_Client"
 
-- Refer to the *SetupApplications.ps1* script source for additional options and examples.
+    -Location <String>
+        'Used to set metadata for specific region (for example: china, germany). Ignore it in global environment.'
 
-Running the script will prompt you to sign in to an account with admin privileges for the Azure AD tenant. Once signed in, the script will create the web and native applications to represent your Service Fabric cluster. The script will also print the JSON required by the Azure Resource Manager template when you go on to [create your Service Fabric cluster](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-cluster-creation-create-template#add-azure-ad-configuration-to-use-azure-ad-for-client-access), so be sure to save it somewhere.
+    -AddResourceAccess [<SwitchParameter>]
+        Used to add the cluster applications resource access to Entra application explicitly when AAD is not able to add
+        automatically. This may happen when the user account does not have adequate permission under this subscription.
 
-### Create Azure AD users
+    -AddVisualStudioAccess [<SwitchParameter>]
+        Used to add the Visual Studio MSAL client ids to the cluster application
+            'https://learn.microsoft.com/en-us/azure/service-fabric/service-fabric-manage-application-in-visual-studio'
+            Visual Studio 2022 and future versions: '04f0c124-f2bc-4f59-8241-bf6df9866bbd'
+            Visual Studio 2019 and earlier: '872cd9fa-d31f-45e0-9eab-6e460a02d1f1'
 
-Run **SetupUser.ps1** to create *read-only* and *admin* user roles for your cluster, using the `$ConfigObj` returned when [creating your Azure AD applications](#create-azure-ad-applications). For example:
+    -SignInAudience <String>
+        Sign in audience option for selection of Applicaiton AAD tenant configuration type. Default selection is 'AzureADMyOrg'
+        'AzureADMyOrg', 'AzureADMultipleOrgs', 'AzureADandPersonalMicrosoftAccount'
+
+    -TimeoutMin <Int32>
+        Script execution retry wait timeout in minutes. Default is 5 minutes. If script times out, it can be re-executed and will       
+        continue configuration as script is idempotent.
+
+    -LogFile <String>
+        Log file path to save script transcript logs.
+
+    -Force [<SwitchParameter>]
+        Use Force switch to force new authorization to acquire new token.
+
+    -Remove [<SwitchParameter>]
+        Use Remove to remove AAD configuration for provided cluster.
+
+    -------------------------- EXAMPLE 1 --------------------------
+    PS > .\SetupApplications.ps1 -TenantId '4f812c74-978b-4b0e-acf5-06ffca635c0e' `
+            -ClusterName 'MyCluster' `
+            -WebApplicationUri 'api://4f812c74-978b-4b0e-acf5-06ffca635c0e/mycluster' `
+            -SpaApplicationReplyUrl 'https://mycluster.westus.cloudapp.azure.com:19080/explorer/index.html'
+
+    Setup tenant with default settings generated from a friendly cluster name.
+
+    -------------------------- EXAMPLE 2 --------------------------
+    PS > .\SetupApplications.ps1 -TenantId '4f812c74-978b-4b0e-acf5-06ffca635c0e' `
+            -WebApplicationName 'SFWeb' `
+            -WebApplicationUri 'https://mycluster.contoso.com' `
+            -SpaApplicationReplyUrl 'https://mycluster.contoso:19080/explorer/index.html' `
+            -NativeClientApplicationName 'SFnative'
+
+    Setup tenant with explicit application settings.
+
+    -------------------------- EXAMPLE 3 --------------------------
+    PS > $ConfigObj = .\SetupApplications.ps1 -TenantId '4f812c74-978b-4b0e-acf5-06ffca635c0e' `
+            -ClusterName 'MyCluster' `
+            -WebApplicationUri 'api://4f812c74-978b-4b0e-acf5-06ffca635c0e/mycluster' `
+            -SpaApplicationReplyUrl 'https://mycluster.westus.cloudapp.azure.com:19080/explorer/index.html'
+
+    Setup and save the setup result into a temporary variable to pass into SetupUser.ps1
+
+    -------------------------- EXAMPLE 4 --------------------------
+    PS > .\SetupApplications.ps1 -TenantId '4f812c74-978b-4b0e-acf5-06ffca635c0e' `
+            -WebApplicationUri 'api://4f812c74-978b-4b0e-acf5-06ffca635c0e/mycluster' `
+            -SpaApplicationReplyUrl 'https://mycluster.westus.cloudapp.azure.com:19080/explorer/index.html' `
+            -AddResourceAccess `
+            -AddVisualStudioAccess
+
+    Setup tenant with explicit application settings and add explicit resource access to Entra application.
+```
+
+Running the script will prompt you to sign in to an account with admin privileges for the Entra tenant. Once signed in, the script will create the web and native applications to represent your Service Fabric cluster. The script will also print the JSON required by the Azure Resource Manager template when you go on to [create your Service Fabric cluster](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-cluster-creation-create-template#add-entra-configuration-to-use-entra-for-client-access), so be sure to save it somewhere.
+
+### Create Entra users
+
+Run **SetupUser.ps1** to create *read-only* and *admin* user roles for your cluster, using the `$ConfigObj` returned when [creating your Entra applications](#create-entra-applications). For example:
 
 ```PowerShell
 .\SetupUser.ps1 -ConfigObj $ConfigObj -UserName 'TestUser' -Password 'P@ssword!123'
@@ -66,9 +149,9 @@ Run **SetupUser.ps1** to create *read-only* and *admin* user roles for your clus
 
 Refer to the *SetupUser.ps1* script source for additional options and examples.
 
-### Delete Azure AD applications and users
+### Delete Entra applications and users
 
-Run same scripts with '-remove' switch if the Azure AD applications or user configurations need to be removed.
+Run same scripts with '-remove' switch if the Entra applications or user configurations need to be removed.
 
 ```PowerShell
 $ConfigObj = .\SetupApplications.ps1 -TenantId '<tenant_id>' -ClusterName '<cluster_name>' -SpaApplicationReplyUrl 'https://<cluster_domain>:19080/Explorer' -WebApplicationUri 'api://<tenant_id>/<cluster_name>' -AddResourceAccess -remove
@@ -80,13 +163,69 @@ $ConfigObj = .\SetupApplications.ps1 -TenantId '<tenant_id>' -ClusterName '<clus
 .\SetupUser.ps1 -ConfigObj $ConfigObj -UserName 'TestUser' -Password 'P@ssword!123' -remove -force
 ```
 
-Refer to *CleanupApplications.ps1* and *CleanupUser.ps1* scripts for additional options and examples.
+### SetupUser Parameters
 
+```powershell
+>help .\SetupUser.ps1 -full        
+PARAMETERS
+    -TenantId <String>
+        ID of tenant hosting Service Fabric cluster.
+                
+    -WebApplicationId <String>
+        ObjectId of web application representing Service Fabric cluster.
+                
+    -UserName <String>
+                
+    -Password <String>
+        Password of new user.
+        
+    -IsAdmin [<SwitchParameter>]
+        User is assigned admin app role if indicated; otherwise, readonly app role.
+        
+    -ConfigObj <Hashtable>
+        Temporary variable of tenant setup result returned by SetupApplications.ps1.
 
-### Update an existing Azure Ad Application
-Update an existing Azure Ad Application to migrate the web redirect URIs to SPA redirect URIs.
+    -Location <String>
+        Used to set metadata for specific region (for example: china). Ignore it in global environment.
+
+    -Domain <String>
+        Domain is the verified domain being used for user account configuration.
+
+    -TimeoutMin <Int32>
+        Script execution retry wait timeout in minutes. Default is 5 minutes. If script times out, it can be re-executed and will       
+        continue configuration as script is idempotent.
+
+    -LogFile <String>
+
+    -Remove [<SwitchParameter>]
+        Use Remove to remove AAD configuration and optionally user.
+
+    -Force [<SwitchParameter>]
+        Use Force switch to force removal of AAD user account if specifying -remove.
+
+    -------------------------- EXAMPLE 1 --------------------------
+
+    PS > . Scripts\SetupUser.ps1 -ConfigObj $ConfigObj -UserName 'SFuser' -Password 'Test4321'
+
+    Setup up a read-only user with return SetupApplications.ps1
+
+    -------------------------- EXAMPLE 2 --------------------------
+
+    PS > . Scripts\SetupUser.ps1 -TenantId '7b25ab7e-cd25-4f0c-be06-939424dc9cc9' `
+            -WebApplicationId '9bf7c6f3-53ce-4c63-8ab3-928c7bf4200b' `
+            -UserName 'SFAdmin' `
+            -Password 'Test4321' `
+            -IsAdmin
+
+    Setup up an admin user providing values for parameters
+```
+
+### Update an existing Entra Application
+
+Update an existing Entra Application to migrate the web redirect URIs to SPA redirect URIs.
 This will update the Application registration by moving any web redirect URIs that contain the port(by default 19080) to SPA redirect URIs and ensuring they end with /Explorer/index.html
 The webApplicationId can be found in azure portal by checking the Application (client) ID section of the app registration essentials or the ClusterApplication section of your cluster's  azureActiveryDirectory section of your arm template.
+
 ```PowerShell
 
 # The WhatIf flag will show what web redirect URIs would be removed and SPA redirect URIs would be created without making the change.
@@ -100,7 +239,107 @@ The webApplicationId can be found in azure portal by checking the Application (c
 
 ```
 
+### UpdateApplication Parameters
+
+```powershell
+>help .\UpdateApplication.ps1 -full
+
+PARAMETERS
+    -WebApplicationId <String>
+        The WebApplicationId of the application to update
+                
+    -TimeoutMin <Int32>
+        The timeout in minutes for the script to run
+                
+    -HttpPort <Int32>
+        The port to search for in the redirect URIs
+                
+    -LogFile <String>
+        The path to the log file
+        
+    -TenantId <String>
+        The tenant id of the application to update
+        
+    -WhatIf [<SwitchParameter>]
+        The switch to run the script in whatif mode
+        
+    -------------------------- EXAMPLE 1 --------------------------
+
+    PS > .\UpdateApplication.ps1 -WebApplicationId 'https://mysftestcluster.contoso.com' `
+        -TenantId '00000000-0000-0000-0000-000000000000' `
+        -TimeoutMin 5 `
+        -HttpPort 19080 `
+        -LogFile 'C:\temp\update-app.log' `
+        -WhatIf
+```
+
+## Update an existing Cluster
+
+Run **SetupClusterResource.ps1** to update an existing cluster that was created without Entra, using the `$ConfigObj` returned when [creating your Entra applications](#create-entra-applications). For example:
+
+```powershell
+$ConfigObj = .\SetupClusterResource.ps1 -TenantId '<tenant_id>' `
+  -ClusterName '<cluster_name>' `
+  -SpaApplicationReplyUrl 'https://<cluster_domain>:19080/Explorer' `
+  -WebApplicationUri 'api://<tenant_id>/<cluster_name>' `
+  -AddResourceAccess
+```
+
+### SetupClusterResource Parameters
+
+```powershell
+>help .\SetupClusterResource.ps1 -full
+
+PARAMETERS
+    -ConfigObj <Hashtable>
+        hashtable containing configuration values
+                
+    -TenantId <String>
+        tenant id of the application to update
+        
+    -ClusterApplication <String>
+        the application id of the cluster application
+        
+    -ClientApplication <String>
+        the application id of the client application
+        
+    -ResourceGroupName <String>
+        the resource group name of the cluster
+        
+    -ClusterName <String>
+        the name of the cluster
+
+    -DeploymentName <String>
+        the name of the deployment
+
+    -TemplateFile <String>
+        the path to the template file
+
+    -WhatIf [<SwitchParameter>]
+        the switch to run the script in whatif mode
+
+    -Force [<SwitchParameter>]
+
+    -------------------------- EXAMPLE 1 --------------------------
+
+    PS > .\setupClusterResource.ps1 -tenantId 'cb4dc457-01c8-40c7-855a-5468ebd5bc74' `
+            -clusterApplication 'e6bba8d5-3fb6-47ac-9927-2a50cf763d36' `
+            -clientApplication '2324af84-f14b-4ee8-a695-6b464f8dbb92' `
+            -resourceGroupName 'mysftestcluster' `
+            -clusterName 'mysftestcluster'
+
+    -------------------------- EXAMPLE 2 --------------------------
+
+    PS > .\setupClusterResource.ps1
+            -ConfigObj $ConfigObj `
+            -resourceGroupName 'mysftestcluster' `
+            -clusterName 'mysftestcluster'
+```
+
 ## Resources
 
-- [Service Fabric: Set up Azure Active Directory for client authentication](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-cluster-creation-setup-aad)
-- [Active Directory: Set up a dev environment](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-create-new-tenant)
+* [Service Fabric: Set up Microsoft Entra ID for client authentication](https://learn.microsoft.com/azure/service-fabric/service-fabric-cluster-creation-setup-aad)
+
+* [Service Fabric: Set up Microsoft Entra ID for client authentication in the Azure portal](https://learn.microsoft.com/azure/service-fabric/service-fabric-cluster-creation-setup-azure-ad-via-portal)
+
+* [Active Directory: Set up a dev environment](https://learn.microsoft.com/azure/active-directory/develop/quickstart-create-new-tenant)

--- a/README.md
+++ b/README.md
@@ -44,22 +44,24 @@ $ConfigObj = .\SetupApplications.ps1 -TenantId '<tenant_id>' `
 
 ### SetupApplications Parameters
 
+<details><summary>Click to expand</summary>
+
 ```powershell
->help .\SetupApplications.ps1 -full    
+>help .\SetupApplications.ps1 -full
 PARAMETERS
     -TenantId <String>
         ID of tenant hosting Service Fabric cluster.
-        
+
     -WebApplicationName <String>
         Name of web application representing Service Fabric cluster.
-        
+
     -WebApplicationUri <String>
-        App ID URI of web application. If using https:// format, the domain has to be a verified domain. Format: https://<Domain name 
+        App ID URI of web application. If using https:// format, the domain has to be a verified domain. Format: https://<Domain name
         of cluster>
         Example: 'https://mycluster.contoso.com'
         Alternatively api:// format can be used which does not require a verified domain. Format: api://<tenant id>/<cluster name>
         Example: 'api://4f812c74-978b-4b0e-acf5-06ffca635c0e/mycluster'
-        
+
     -SpaApplicationReplyUrl <String>
         Reply URL of spa application. Format: https://<Domain name of cluster>:<Service Fabric Http gateway port>
         Example: 'https://mycluster.westus.cloudapp.azure.com:19080/Explorer/index.html'
@@ -68,7 +70,7 @@ PARAMETERS
         Name of native client application representing client.
 
     -ClusterName <String>
-        A friendly Service Fabric cluster name. Application settings generated from cluster name: WebApplicationName = ClusterName +    
+        A friendly Service Fabric cluster name. Application settings generated from cluster name: WebApplicationName = ClusterName +
         "_Cluster", NativeClientApplicationName = ClusterName + "_Client"
 
     -Location <String>
@@ -89,7 +91,7 @@ PARAMETERS
         'AzureADMyOrg', 'AzureADMultipleOrgs', 'AzureADandPersonalMicrosoftAccount'
 
     -TimeoutMin <Int32>
-        Script execution retry wait timeout in minutes. Default is 5 minutes. If script times out, it can be re-executed and will       
+        Script execution retry wait timeout in minutes. Default is 5 minutes. If script times out, it can be re-executed and will
         continue configuration as script is idempotent.
 
     -LogFile <String>
@@ -136,6 +138,8 @@ PARAMETERS
     Setup tenant with explicit application settings and add explicit resource access to Entra application.
 ```
 
+</details>
+
 Running the script will prompt you to sign in to an account with admin privileges for the Entra tenant. Once signed in, the script will create the web and native applications to represent your Service Fabric cluster. The script will also print the JSON required by the Azure Resource Manager template when you go on to [create your Service Fabric cluster](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-cluster-creation-create-template#add-entra-configuration-to-use-entra-for-client-access), so be sure to save it somewhere.
 
 ### Create Entra users
@@ -165,23 +169,25 @@ $ConfigObj = .\SetupApplications.ps1 -TenantId '<tenant_id>' -ClusterName '<clus
 
 ### SetupUser Parameters
 
+<details><summary>Click to expand</summary>
+
 ```powershell
->help .\SetupUser.ps1 -full        
+>help .\SetupUser.ps1 -full
 PARAMETERS
     -TenantId <String>
         ID of tenant hosting Service Fabric cluster.
-                
+
     -WebApplicationId <String>
         ObjectId of web application representing Service Fabric cluster.
-                
+
     -UserName <String>
-                
+
     -Password <String>
         Password of new user.
-        
+
     -IsAdmin [<SwitchParameter>]
         User is assigned admin app role if indicated; otherwise, readonly app role.
-        
+
     -ConfigObj <Hashtable>
         Temporary variable of tenant setup result returned by SetupApplications.ps1.
 
@@ -192,7 +198,7 @@ PARAMETERS
         Domain is the verified domain being used for user account configuration.
 
     -TimeoutMin <Int32>
-        Script execution retry wait timeout in minutes. Default is 5 minutes. If script times out, it can be re-executed and will       
+        Script execution retry wait timeout in minutes. Default is 5 minutes. If script times out, it can be re-executed and will
         continue configuration as script is idempotent.
 
     -LogFile <String>
@@ -220,6 +226,8 @@ PARAMETERS
     Setup up an admin user providing values for parameters
 ```
 
+</details>
+
 ### Update an existing Entra Application
 
 Update an existing Entra Application to migrate the web redirect URIs to SPA redirect URIs.
@@ -234,12 +242,14 @@ The webApplicationId can be found in azure portal by checking the Application (c
 
 .\UpdateApplication.ps1 -WebApplicationId '<web_app_id>' -TenantId '<tenant_id>'
 
-# Update for clusters not using standard 19080 http port 
+# Update for clusters not using standard 19080 http port
 .\UpdateApplication.ps1 -WebApplicationId '<web_app_id>' -TenantId '<tenant_id>' -HttpPort 19007
 
 ```
 
 ### UpdateApplication Parameters
+
+<details><summary>Click to expand</summary>
 
 ```powershell
 >help .\UpdateApplication.ps1 -full
@@ -247,22 +257,22 @@ The webApplicationId can be found in azure portal by checking the Application (c
 PARAMETERS
     -WebApplicationId <String>
         The WebApplicationId of the application to update
-                
+
     -TimeoutMin <Int32>
         The timeout in minutes for the script to run
-                
+
     -HttpPort <Int32>
         The port to search for in the redirect URIs
-                
+
     -LogFile <String>
         The path to the log file
-        
+
     -TenantId <String>
         The tenant id of the application to update
-        
+
     -WhatIf [<SwitchParameter>]
         The switch to run the script in whatif mode
-        
+
     -------------------------- EXAMPLE 1 --------------------------
 
     PS > .\UpdateApplication.ps1 -WebApplicationId 'https://mysftestcluster.contoso.com' `
@@ -272,6 +282,8 @@ PARAMETERS
         -LogFile 'C:\temp\update-app.log' `
         -WhatIf
 ```
+
+</details>
 
 ## Update an existing Cluster
 
@@ -287,25 +299,27 @@ $ConfigObj = .\SetupClusterResource.ps1 -TenantId '<tenant_id>' `
 
 ### SetupClusterResource Parameters
 
+<details><summary>Click to expand</summary>
+
 ```powershell
 >help .\SetupClusterResource.ps1 -full
 
 PARAMETERS
     -ConfigObj <Hashtable>
         hashtable containing configuration values
-                
+
     -TenantId <String>
         tenant id of the application to update
-        
+
     -ClusterApplication <String>
         the application id of the cluster application
-        
+
     -ClientApplication <String>
         the application id of the client application
-        
+
     -ResourceGroupName <String>
         the resource group name of the cluster
-        
+
     -ClusterName <String>
         the name of the cluster
 
@@ -335,6 +349,8 @@ PARAMETERS
             -resourceGroupName 'mysftestcluster' `
             -clusterName 'mysftestcluster'
 ```
+
+</details>
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,16 @@ PARAMETERS
     -Remove [<SwitchParameter>]
         Use Remove to remove AAD configuration for provided cluster.
 
-    -------------------------- EXAMPLE 1 --------------------------
+    -MGClientId <Guid>
+        Optional AAD client id for management group. If not provided, it will use default client id.
+
+    -MGClientSecret <String>
+        Optional AAD client secret for management group.
+
+    -MGGrantType <String>
+        Optional AAD grant type for management group. Default is 'device_code'.
+
+-------------------------- EXAMPLE 1 --------------------------
     PS > .\SetupApplications.ps1 -TenantId '4f812c74-978b-4b0e-acf5-06ffca635c0e' `
             -ClusterName 'MyCluster' `
             -WebApplicationUri 'api://4f812c74-978b-4b0e-acf5-06ffca635c0e/mycluster' `

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This repo provides the following scripts for Azure AD:
 Run **SetupApplications.ps1** to create two Azure AD applications (web and native applications) to control access to the cluster, storing the output into a variable to reuse when [creating Azure AD users](#create-azure-ad-users).
 
 ```PowerShell
-$Configobj = .\SetupApplications.ps1 -TenantId '<tenant_id>' -ClusterName '<cluster_name>' -WebApplicationReplyUrl 'https://<cluster_domain>:19080/Explorer' -WebApplicationUri 'api://<tenant_id>/<cluster_name>' -AddResourceAccess
+$ConfigObj = .\SetupApplications.ps1 -TenantId '<tenant_id>' -ClusterName '<cluster_name>' -WebApplicationReplyUrl 'https://<cluster_domain>:19080/Explorer' -WebApplicationUri 'api://<tenant_id>/<cluster_name>' -AddResourceAccess
 ```
 
 - **TenantId**: You can find this by executing the PowerShell command `Get-AzureSubscription`.
@@ -57,11 +57,11 @@ Running the script will prompt you to sign in to an account with admin privilege
 
 ### Create Azure AD users
 
-Run **SetupUser.ps1** to create *read-only* and *admin* user roles for your cluster, using the `$Configobj` returned when [creating your Azure AD applications](#create-azure-ad-applications). For example:
+Run **SetupUser.ps1** to create *read-only* and *admin* user roles for your cluster, using the `$ConfigObj` returned when [creating your Azure AD applications](#create-azure-ad-applications). For example:
 
 ```PowerShell
-.\SetupUser.ps1 -ConfigObj $Configobj -UserName 'TestUser' -Password 'P@ssword!123'
-.\SetupUser.ps1 -ConfigObj $Configobj -UserName 'TestAdmin' -Password 'P@ssword!123' -IsAdmin
+.\SetupUser.ps1 -ConfigObj $ConfigObj -UserName 'TestUser' -Password 'P@ssword!123'
+.\SetupUser.ps1 -ConfigObj $ConfigObj -UserName 'TestAdmin' -Password 'P@ssword!123' -IsAdmin
 ```
 
 Refer to the *SetupUser.ps1* script source for additional options and examples.
@@ -71,13 +71,13 @@ Refer to the *SetupUser.ps1* script source for additional options and examples.
 Run same scripts with '-remove' switch if the Azure AD applications or user configurations need to be removed.
 
 ```PowerShell
-$Configobj = .\SetupApplications.ps1 -TenantId '<tenant_id>' -ClusterName '<cluster_name>' -WebApplicationReplyUrl 'https://<cluster_domain>:19080/Explorer' -WebApplicationUri 'api://<tenant_id>/<cluster_name>' -AddResourceAccess -remove
+$ConfigObj = .\SetupApplications.ps1 -TenantId '<tenant_id>' -ClusterName '<cluster_name>' -WebApplicationReplyUrl 'https://<cluster_domain>:19080/Explorer' -WebApplicationUri 'api://<tenant_id>/<cluster_name>' -AddResourceAccess -remove
 
 # remove configuration from user
-.\SetupUser.ps1 -ConfigObj $Configobj -UserName 'TestUser' -Password 'P@ssword!123' -remove
+.\SetupUser.ps1 -ConfigObj $ConfigObj -UserName 'TestUser' -Password 'P@ssword!123' -remove
 
 # remove user
-.\SetupUser.ps1 -ConfigObj $Configobj -UserName 'TestUser' -Password 'P@ssword!123' -remove -force
+.\SetupUser.ps1 -ConfigObj $ConfigObj -UserName 'TestUser' -Password 'P@ssword!123' -remove -force
 ```
 
 Refer to *CleanupApplications.ps1* and *CleanupUser.ps1* scripts for additional options and examples.

--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@ PowerShell scripts for setting up Azure Active Directory (AAD/Entra) to authenti
 
 ## Features
 
-This repo provides the following scripts for Entra:
+This repo provides the following scripts for Entra that can configure the following:
 
 * Create Entra applications (web, native) to control access to your Service Fabric cluster
 * Delete existing Entra applications (web, native) for controlling your cluster
 * Create a new Entra user
 * Delete an existing Entra user
+* Add Visual Studio client ids to the cluster application for MSAL authentication
 
 ## Getting Started
 
@@ -43,8 +44,6 @@ $ConfigObj = .\SetupApplications.ps1 -TenantId '<tenant_id>' `
 ```
 
 ### SetupApplications Parameters
-
-<details><summary>Click to expand</summary>
 
 ```powershell
 >help .\SetupApplications.ps1 -full
@@ -147,8 +146,6 @@ PARAMETERS
     Setup tenant with explicit application settings and add explicit resource access to Entra application.
 ```
 
-</details>
-
 Running the script will prompt you to sign in to an account with admin privileges for the Entra tenant. Once signed in, the script will create the web and native applications to represent your Service Fabric cluster. The script will also print the JSON required by the Azure Resource Manager template when you go on to [create your Service Fabric cluster](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-cluster-creation-create-template#add-entra-configuration-to-use-entra-for-client-access), so be sure to save it somewhere.
 
 ### Create Entra users
@@ -177,8 +174,6 @@ $ConfigObj = .\SetupApplications.ps1 -TenantId '<tenant_id>' -ClusterName '<clus
 ```
 
 ### SetupUser Parameters
-
-<details><summary>Click to expand</summary>
 
 ```powershell
 >help .\SetupUser.ps1 -full
@@ -235,8 +230,6 @@ PARAMETERS
     Setup up an admin user providing values for parameters
 ```
 
-</details>
-
 ### Update an existing Entra Application
 
 Update an existing Entra Application to migrate the web redirect URIs to SPA redirect URIs.
@@ -257,8 +250,6 @@ The webApplicationId can be found in azure portal by checking the Application (c
 ```
 
 ### UpdateApplication Parameters
-
-<details><summary>Click to expand</summary>
 
 ```powershell
 >help .\UpdateApplication.ps1 -full
@@ -292,8 +283,6 @@ PARAMETERS
         -WhatIf
 ```
 
-</details>
-
 ## Update an existing Cluster
 
 Run **SetupClusterResource.ps1** to update an existing cluster that was created without Entra, using the `$ConfigObj` returned when [creating your Entra applications](#create-entra-applications). For example:
@@ -307,8 +296,6 @@ $ConfigObj = .\SetupClusterResource.ps1 -TenantId '<tenant_id>' `
 ```
 
 ### SetupClusterResource Parameters
-
-<details><summary>Click to expand</summary>
 
 ```powershell
 >help .\SetupClusterResource.ps1 -full
@@ -359,8 +346,6 @@ PARAMETERS
             -clusterName 'mysftestcluster'
 ```
 
-</details>
-
 ## Resources
 
 * [Service Fabric: Set up Microsoft Entra ID for client authentication](https://learn.microsoft.com/azure/service-fabric/service-fabric-cluster-creation-setup-aad)
@@ -368,3 +353,5 @@ PARAMETERS
 * [Service Fabric: Set up Microsoft Entra ID for client authentication in the Azure portal](https://learn.microsoft.com/azure/service-fabric/service-fabric-cluster-creation-setup-azure-ad-via-portal)
 
 * [Active Directory: Set up a dev environment](https://learn.microsoft.com/azure/active-directory/develop/quickstart-create-new-tenant)
+
+* [Use Visual Studio to simplify writing and managing your Service Fabric applications](https://learn.microsoft.com/azure/service-fabric/service-fabric-manage-application-in-visual-studio)

--- a/README.md
+++ b/README.md
@@ -80,12 +80,6 @@ PARAMETERS
         Used to add the cluster applications resource access to Entra application explicitly when AAD is not able to add
         automatically. This may happen when the user account does not have adequate permission under this subscription.
 
-    -AddVisualStudioAccess [<SwitchParameter>]
-        Used to add the Visual Studio MSAL client ids to the cluster application
-            'https://learn.microsoft.com/en-us/azure/service-fabric/service-fabric-manage-application-in-visual-studio'
-            Visual Studio 2022 and future versions: '04f0c124-f2bc-4f59-8241-bf6df9866bbd'
-            Visual Studio 2019 and earlier: '872cd9fa-d31f-45e0-9eab-6e460a02d1f1'
-
     -SignInAudience <String>
         Sign in audience option for selection of Applicaiton AAD tenant configuration type. Default selection is 'AzureADMyOrg'
         'AzureADMyOrg', 'AzureADMultipleOrgs', 'AzureADandPersonalMicrosoftAccount'
@@ -141,8 +135,7 @@ PARAMETERS
     PS > .\SetupApplications.ps1 -TenantId '4f812c74-978b-4b0e-acf5-06ffca635c0e' `
             -WebApplicationUri 'api://4f812c74-978b-4b0e-acf5-06ffca635c0e/mycluster' `
             -SpaApplicationReplyUrl 'https://mycluster.westus.cloudapp.azure.com:19080/explorer/index.html' `
-            -AddResourceAccess `
-            -AddVisualStudioAccess
+            -AddResourceAccess
 
     Setup tenant with explicit application settings and add explicit resource access to Entra application.
 ```

--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ PARAMETERS
         Used to add the cluster applications resource access to Entra application explicitly when AAD is not able to add
         automatically. This may happen when the user account does not have adequate permission under this subscription.
 
+    -AddVisualStudioAccess [<SwitchParameter>]
+        Used to add the Visual Studio MSAL client ids to the cluster application
+            'https://learn.microsoft.com/en-us/azure/service-fabric/service-fabric-manage-application-in-visual-studio'
+            Visual Studio 2022 and future versions: '04f0c124-f2bc-4f59-8241-bf6df9866bbd'
+            Visual Studio 2019 and earlier: '872cd9fa-d31f-45e0-9eab-6e460a02d1f1'
+
     -SignInAudience <String>
         Sign in audience option for selection of Applicaiton AAD tenant configuration type. Default selection is 'AzureADMyOrg'
         'AzureADMyOrg', 'AzureADMultipleOrgs', 'AzureADandPersonalMicrosoftAccount'
@@ -135,7 +141,8 @@ PARAMETERS
     PS > .\SetupApplications.ps1 -TenantId '4f812c74-978b-4b0e-acf5-06ffca635c0e' `
             -WebApplicationUri 'api://4f812c74-978b-4b0e-acf5-06ffca635c0e/mycluster' `
             -SpaApplicationReplyUrl 'https://mycluster.westus.cloudapp.azure.com:19080/explorer/index.html' `
-            -AddResourceAccess
+            -AddResourceAccess `
+            -AddVisualStudioAccess
 
     Setup tenant with explicit application settings and add explicit resource access to Entra application.
 ```

--- a/SetupApplications.ps1
+++ b/SetupApplications.ps1
@@ -459,19 +459,10 @@ function confirm-visualStudioAccess($webApp, [guid]$oauthPermissionsId) {
     $preAuthorizedApplications = get-preauthorizedApplications -applicationId $webApp.id -applicationIds $visualStudioClientIds -delegatedPermissionIds @($oauthPermissionsId)
     if ($preAuthorizedApplications) {
         write-host "visual studio preauthorized applications already exists."
-        # todo: should we remove if $AddVisualStudioAccess is false?
         if (!$AddVisualStudioAccess) {
-            $remove = $true
-
-            if (!$Force) {
-                $remove = (read-host "Do you want to remove visual studio preauthorized applications? (y/n)") -ieq 'y'
-            }
-
-            if ($remove) {
-                write-host "removing visual studio preauthorized applications" -ForegroundColor Yellow
-                remove-preauthorizedApplications -webApp $webApp -applicationIds $visualStudioClientIds -delegatedPermissionIds @($oauthPermissionsId)
-                return
-            }
+            write-host "removing visual studio preauthorized applications" -ForegroundColor Yellow
+            remove-preauthorizedApplications -webApp $webApp -applicationIds $visualStudioClientIds -delegatedPermissionIds @($oauthPermissionsId)
+            return
         }
     }
     else {

--- a/SetupApplications.ps1
+++ b/SetupApplications.ps1
@@ -459,10 +459,19 @@ function confirm-visualStudioAccess($webApp, [guid]$oauthPermissionsId) {
     $preAuthorizedApplications = get-preauthorizedApplications -applicationId $webApp.id -applicationIds $visualStudioClientIds -delegatedPermissionIds @($oauthPermissionsId)
     if ($preAuthorizedApplications) {
         write-host "visual studio preauthorized applications already exists."
+        # todo: should we remove if $AddVisualStudioAccess is false?
         if (!$AddVisualStudioAccess) {
-            write-host "removing visual studio preauthorized applications" -ForegroundColor Yellow
-            remove-preauthorizedApplications -webApp $webApp -applicationIds $visualStudioClientIds -delegatedPermissionIds @($oauthPermissionsId)
-            return
+            $remove = $true
+
+            if (!$Force) {
+                $remove = (read-host "Do you want to remove visual studio preauthorized applications? (y/n)") -ieq 'y'
+            }
+
+            if ($remove) {
+                write-host "removing visual studio preauthorized applications" -ForegroundColor Yellow
+                remove-preauthorizedApplications -webApp $webApp -applicationIds $visualStudioClientIds -delegatedPermissionIds @($oauthPermissionsId)
+                return
+            }
         }
     }
     else {

--- a/SetupApplications.ps1
+++ b/SetupApplications.ps1
@@ -143,7 +143,7 @@ $msGraphUserReadId = 'e1fe6dd8-ba31-4d61-89e7-88639da4683d'
 function main () {
     try {
         if ($logFile) {
-            Start-Transcript -path $logFile -Force
+            Start-Transcript -path $logFile -Force | out-null
         }
 
         enable-AAD
@@ -154,7 +154,7 @@ function main () {
     }
     finally {
         if ($logFile) {
-            Stop-Transcript
+            Stop-Transcript | out-null
         }
     }
 }

--- a/SetupApplications.ps1
+++ b/SetupApplications.ps1
@@ -143,7 +143,7 @@ $msGraphUserReadId = 'e1fe6dd8-ba31-4d61-89e7-88639da4683d'
 function main () {
     try {
         if ($logFile) {
-            Start-Transcript -path $logFile -Force
+            Start-Transcript -path $logFile -Force | Out-Null
         }
 
         enable-AAD
@@ -154,7 +154,7 @@ function main () {
     }
     finally {
         if ($logFile) {
-            Stop-Transcript
+            Stop-Transcript | Out-Null
         }
     }
 }

--- a/SetupApplications.ps1
+++ b/SetupApplications.ps1
@@ -132,10 +132,10 @@ Param
     $remove
 )
 
-$headers = $null
+# load common functions
 . "$PSScriptRoot\Common.ps1"
-$graphAPIFormat = $resourceUrl + "/v1.0/" + $TenantId + "/{0}"
-$global:ConfigObj = @{}
+
+$graphAPIFormat = $global:ConfigObj.ResourceUrl + "/v1.0/" + $global:ConfigObj.TenantId + "/{0}"
 $sleepSeconds = 5
 $msGraphUserReadAppId = '00000003-0000-0000-c000-000000000000'
 $msGraphUserReadId = 'e1fe6dd8-ba31-4d61-89e7-88639da4683d'
@@ -146,11 +146,10 @@ function main () {
             Start-Transcript -path $logFile -Force | Out-Null
         }
 
-        enable-AAD
+        setup-Applications
     }
     catch [Exception] {
-        $errorString = "exception: $($psitem.Exception.Response.StatusCode.value__)`r`nexception:`r`n$($psitem.Exception.Message)`r`n$($error | out-string)`r`n$($psitem.ScriptStackTrace)"
-        write-error $errorString
+        write-errorMessage $psitem
     }
     finally {
         if ($logFile) {
@@ -189,7 +188,7 @@ function add-appRegistration($WebApplicationUri, $SpaApplicationReplyUrl, $requi
     }
     
     $spaAppResource = @{
-        redirectUris          = @($SpaApplicationReplyUrl)
+        redirectUris = @($SpaApplicationReplyUrl)
     }
     
     if ($AddResourceAccess) {
@@ -381,115 +380,6 @@ function add-servicePrincipalGrantScope($clientId, $resourceId, $scope) {
     return $result
 }
 
-function enable-AAD() {
-    Write-Host 'TenantId = ' $TenantId
-    $ConfigObj.ClusterName = $clusterName
-    $ConfigObj.TenantId = $TenantId
-    $webApp = $null
-
-    if (!$webApplicationName) {
-        $webApplicationName = "ServiceFabricCluster"
-    }
-    
-    if (!$WebApplicationUri) {
-        $WebApplicationUri = "https://ServiceFabricCluster"
-    }
-    
-    if (!$NativeClientApplicationName) {
-        $NativeClientApplicationName = "ServiceFabricClusterNativeClient"
-    }
-
-    # MS Graph access User.Read
-    $requiredResourceAccess = @(@{
-            resourceAppId  = $msGraphUserReadAppId
-            resourceAccess = @(@{
-                    id   = $msGraphUserReadId
-                    type = "Scope"
-                })
-        })
-
-    # cleanup
-    if ($remove) {
-        write-host "removing web service principals"
-        $result = remove-servicePrincipal
-    
-        write-host "removing web service principals"
-        $result = $result -and (remove-servicePrincipalNa)
-
-        write-warning "removing app registration"
-        $result = $result -and (remove-appRegistration -WebApplicationUri $WebApplicationUri)
-
-        write-warning "removing native app registration"
-        $result = $result -and (remove-nativeClient -nativeClientApplicationName $NativeClientApplicationName)
-        write-host "removal complete result:$result" -ForegroundColor Green
-        return $ConfigObj
-    }
-    
-    # check / add app registration
-    $webApp = get-appRegistration -WebApplicationUri $WebApplicationUri
-    if (!$webApp) {
-        $webApp = add-appRegistration -WebApplicationUri $WebApplicationUri `
-            -SpaApplicationReplyUrl $SpaApplicationReplyUrl `
-            -requiredResourceAccess $requiredResourceAccess
-    }
-
-    assert-notNull $webApp 'Web Application Creation Failed'
-    $ConfigObj.WebAppId = $webApp.appId
-    Write-Host "Web Application Created: $($webApp.appId)"
-
-    # check / add oauth user_impersonation permissions
-    $oauthPermissionsId = get-OauthPermissions -webApp $webApp
-    if (!$oauthPermissionsId) {
-        $oauthPermissionsId = add-oauthPermissions -webApp $webApp -WebApplicationName $webApplicationName
-    }
-    assert-notNull $oauthPermissionsId 'Web Application Oauth permissions Failed'
-    Write-Host "Web Application Oauth permissions created: $($oauthPermissionsId|convertto-json)"  -ForegroundColor Green
-
-    # check / add servicePrincipal
-    $servicePrincipal = get-servicePrincipal -webApp $webApp
-    if (!$servicePrincipal) {
-        $servicePrincipal = add-servicePrincipal -webApp $webApp -assignmentRequired $true
-    }
-    assert-notNull $servicePrincipal 'service principal configuration failed'
-    Write-Host "Service Principal Created: $($servicePrincipal.appId)" -ForegroundColor Green
-    $ConfigObj.ServicePrincipalId = $servicePrincipal.Id
-
-    # check / add native app
-    $nativeApp = get-nativeClient -NativeClientApplicationName $NativeClientApplicationName -WebApplicationUri $WebApplicationUri
-    if (!$nativeApp) {
-        $nativeApp = add-nativeClient -webApp $webApp -requiredResourceAccess $requiredResourceAccess -oauthPermissionsId $oauthPermissionsId
-    }
-    assert-notNull $nativeApp 'Native Client Application Creation Failed'
-    Write-Host "Native Client Application Created: $($nativeApp.appId)"  -ForegroundColor Green
-    $ConfigObj.NativeClientAppId = $nativeApp.appId
-
-    # check / add native app service principal
-    $servicePrincipalNa = get-servicePrincipal -webApp $nativeApp
-    if (!$servicePrincipalNa) {
-        $servicePrincipalNa = add-servicePrincipal -webApp $nativeApp -assignmentRequired $false
-    }
-    assert-notNull $servicePrincipalNa 'native app service principal configuration failed'
-    Write-Host "Native app service principal created: $($servicePrincipalNa.appId)" -ForegroundColor Green
-
-    # check / add native app service principal AAD
-    $servicePrincipalAAD = add-servicePrincipalGrants -servicePrincipalNa $servicePrincipalNa `
-        -servicePrincipal $servicePrincipal
-
-    assert-notNull $servicePrincipalAAD 'aad app service principal configuration failed'
-    Write-Host "AAD Application Configured: $($servicePrincipalAAD)"  -ForegroundColor Green
-    write-host "ConfigObj: $($ConfigObj|convertto-json)"
-
-    #ARM template AAD resource
-    write-host "-----ARM template-----"
-    write-host "`"azureActiveDirectory`": $(@{
-        tenantId           = $ConfigObj.tenantId
-        clusterApplication = $ConfigObj.WebAppId
-        clientApplication  = $ConfigObj.NativeClientAppId
-    } | ConvertTo-Json)," -ForegroundColor Cyan
-
-    return $ConfigObj
-}
-
 function get-appRegistration($WebApplicationUri) {
     # check for existing app by identifieruri
     $uri = [string]::Format($graphAPIFormat, "applications?`$search=`"identifierUris:$WebApplicationUri`"")
@@ -653,6 +543,115 @@ function remove-servicePrincipalNa() {
     }
 
     return $result
+}
+
+function setup-Applications() {
+    Write-Host 'TenantId = ' $TenantId
+    $ConfigObj.ClusterName = $clusterName
+    $ConfigObj.TenantId = $TenantId
+    $webApp = $null
+
+    if (!$webApplicationName) {
+        $webApplicationName = "ServiceFabricCluster"
+    }
+    
+    if (!$WebApplicationUri) {
+        $WebApplicationUri = "https://ServiceFabricCluster"
+    }
+    
+    if (!$NativeClientApplicationName) {
+        $NativeClientApplicationName = "ServiceFabricClusterNativeClient"
+    }
+
+    # MS Graph access User.Read
+    $requiredResourceAccess = @(@{
+            resourceAppId  = $msGraphUserReadAppId
+            resourceAccess = @(@{
+                    id   = $msGraphUserReadId
+                    type = "Scope"
+                })
+        })
+
+    # cleanup
+    if ($remove) {
+        write-host "removing web service principals"
+        $result = remove-servicePrincipal
+    
+        write-host "removing web service principals"
+        $result = $result -and (remove-servicePrincipalNa)
+
+        write-warning "removing app registration"
+        $result = $result -and (remove-appRegistration -WebApplicationUri $WebApplicationUri)
+
+        write-warning "removing native app registration"
+        $result = $result -and (remove-nativeClient -nativeClientApplicationName $NativeClientApplicationName)
+        write-host "removal complete result:$result" -ForegroundColor Green
+        return $ConfigObj
+    }
+    
+    # check / add app registration
+    $webApp = get-appRegistration -WebApplicationUri $WebApplicationUri
+    if (!$webApp) {
+        $webApp = add-appRegistration -WebApplicationUri $WebApplicationUri `
+            -SpaApplicationReplyUrl $SpaApplicationReplyUrl `
+            -requiredResourceAccess $requiredResourceAccess
+    }
+
+    assert-notNull $webApp 'Web Application Creation Failed'
+    $ConfigObj.WebAppId = $webApp.appId
+    Write-Host "Web Application Created: $($webApp.appId)"
+
+    # check / add oauth user_impersonation permissions
+    $oauthPermissionsId = get-OauthPermissions -webApp $webApp
+    if (!$oauthPermissionsId) {
+        $oauthPermissionsId = add-oauthPermissions -webApp $webApp -WebApplicationName $webApplicationName
+    }
+    assert-notNull $oauthPermissionsId 'Web Application Oauth permissions Failed'
+    Write-Host "Web Application Oauth permissions created: $($oauthPermissionsId|convertto-json)"  -ForegroundColor Green
+
+    # check / add servicePrincipal
+    $servicePrincipal = get-servicePrincipal -webApp $webApp
+    if (!$servicePrincipal) {
+        $servicePrincipal = add-servicePrincipal -webApp $webApp -assignmentRequired $true
+    }
+    assert-notNull $servicePrincipal 'service principal configuration failed'
+    Write-Host "Service Principal Created: $($servicePrincipal.appId)" -ForegroundColor Green
+    $ConfigObj.ServicePrincipalId = $servicePrincipal.Id
+
+    # check / add native app
+    $nativeApp = get-nativeClient -NativeClientApplicationName $NativeClientApplicationName -WebApplicationUri $WebApplicationUri
+    if (!$nativeApp) {
+        $nativeApp = add-nativeClient -webApp $webApp -requiredResourceAccess $requiredResourceAccess -oauthPermissionsId $oauthPermissionsId
+    }
+    assert-notNull $nativeApp 'Native Client Application Creation Failed'
+    Write-Host "Native Client Application Created: $($nativeApp.appId)"  -ForegroundColor Green
+    $ConfigObj.NativeClientAppId = $nativeApp.appId
+
+    # check / add native app service principal
+    $servicePrincipalNa = get-servicePrincipal -webApp $nativeApp
+    if (!$servicePrincipalNa) {
+        $servicePrincipalNa = add-servicePrincipal -webApp $nativeApp -assignmentRequired $false
+    }
+    assert-notNull $servicePrincipalNa 'native app service principal configuration failed'
+    Write-Host "Native app service principal created: $($servicePrincipalNa.appId)" -ForegroundColor Green
+
+    # check / add native app service principal AAD
+    $servicePrincipalAAD = add-servicePrincipalGrants -servicePrincipalNa $servicePrincipalNa `
+        -servicePrincipal $servicePrincipal
+
+    assert-notNull $servicePrincipalAAD 'aad app service principal configuration failed'
+    Write-Host "AAD Application Configured: $($servicePrincipalAAD)"  -ForegroundColor Green
+    write-host "ConfigObj: $($ConfigObj|convertto-json)"
+
+    #ARM template AAD resource
+    write-host "-----ARM template-----"
+    write-host "`"azureActiveDirectory`": $(@{
+        tenantId           = $ConfigObj.tenantId
+        clusterApplication = $ConfigObj.WebAppId
+        clientApplication  = $ConfigObj.NativeClientAppId
+    } | ConvertTo-Json)," -ForegroundColor Cyan
+
+    return $ConfigObj
 }
 
 main

--- a/SetupApplications.ps1
+++ b/SetupApplications.ps1
@@ -349,7 +349,7 @@ function add-preauthorizedApplications($webApp, [guid[]]$applicationIds, [guid[]
         $mergedPermissions = [collections.arraylist]::new()
         [void]$mergedPermissions.AddRange($delegatedPermissionIds)
 
-        $existingApplication = get-preauthorizedApplications -webApp $webApp -applicationIds $applicationId
+        $existingApplication = get-preauthorizedApplications -applicationId $webApp.id -applicationIds $applicationId
         if ($existingApplication) {
             foreach ($existingPermission in $existingApplication.delegatedPermissionIds) {
                 if (!$mergedPermissions -contains $existingPermission) {
@@ -374,7 +374,7 @@ function add-preauthorizedApplications($webApp, [guid[]]$applicationIds, [guid[]
     if ($result) {
         $null = wait-forResult -functionPointer (get-item function:\get-preauthorizedApplications) `
             -message "waiting for preauthorized applications completion" `
-            -webApp $webApp `
+            -applicationId $webApp.id `
             -applicationIds $applicationIds `
             -delegatedPermissionIds $delegatedPermissionIds
     }
@@ -456,7 +456,7 @@ function add-servicePrincipalGrantScope($clientId, $resourceId, $scope) {
 }
 
 function confirm-visualStudioAccess($webApp, [guid]$oauthPermissionsId) {
-    $preAuthorizedApplications = get-preauthorizedApplications -webApp $webApp -applicationIds $visualStudioClientIds -delegatedPermissionIds @($oauthPermissionsId)
+    $preAuthorizedApplications = get-preauthorizedApplications -applicationId $webApp.id -applicationIds $visualStudioClientIds -delegatedPermissionIds @($oauthPermissionsId)
     if ($preAuthorizedApplications) {
         write-host "visual studio preauthorized applications already exists."
         if (!$AddVisualStudioAccess) {
@@ -550,9 +550,9 @@ function get-oauthPermissionGrants($clientId) {
     return $grants.value
 }
 
-function get-preauthorizedApplications($webApp, [guid[]]$applicationIds, [guid[]]$delegatedPermissionIds = $null) {
+function get-preauthorizedApplications([guid]$applicationId, [guid[]]$applicationIds, [guid[]]$delegatedPermissionIds = $null) {
     # check for existing preauthorized applications
-    $webApp = get-appRegistrationById -applicationId $webApp.id
+    $webApp = get-appRegistrationById -applicationId $applicationId
     $preAuthorizedApplications = $webApp.api.preAuthorizedApplications | Where-Object {
         $psitem.appId -in $applicationIds
     }
@@ -644,7 +644,7 @@ function remove-nativeClient($NativeClientApplicationName) {
 
 function remove-preauthorizedApplications($webApp, [guid[]]$applicationIds, [guid[]]$delegatedPermissionIds) {
     # remove preauthorized applications
-    if (!(get-preauthorizedApplications -webApp $webApp -applicationIds $applicationIds -delegatedPermissionIds $delegatedPermissionIds)) {
+    if (!(get-preauthorizedApplications -applicationId $webApp.id -applicationIds $applicationIds -delegatedPermissionIds $delegatedPermissionIds)) {
         write-host "preauthorized applications do not exist." -ForegroundColor Green
         return $webApp.api.preAuthorizedApplications
     }
@@ -655,7 +655,7 @@ function remove-preauthorizedApplications($webApp, [guid[]]$applicationIds, [gui
     
     foreach ($applicationId in $applicationIds) {
         # check for existing preauthorized applications and scrub permissions
-        $existingApplication = get-preauthorizedApplications -webApp $webApp -applicationIds $applicationId -delegatedPermissionIds $delegatedPermissionIds
+        $existingApplication = get-preauthorizedApplications -applicationId $webApp.id -applicationIds $applicationId -delegatedPermissionIds $delegatedPermissionIds
         if (!$existingApplication) {
             continue
         }
@@ -691,7 +691,7 @@ function remove-preauthorizedApplications($webApp, [guid[]]$applicationIds, [gui
         $null = wait-forResult -functionPointer (get-item function:\get-preauthorizedApplications) `
             -message "waiting for preauthorized applications completion" `
             -waitForNullResult `
-            -webApp $webApp `
+            -applicationId $webApp.id `
             -applicationIds $applicationIds `
             -delegatedPermissionIds $delegatedPermissionIds
     }

--- a/SetupApplications.ps1
+++ b/SetupApplications.ps1
@@ -75,7 +75,7 @@ Param
 
     [Parameter(ParameterSetName = 'Customize')]	
     [String]
-    $webApplicationName,
+    $WebApplicationName,
 
     [Parameter(ParameterSetName = 'Customize')]
     [Parameter(ParameterSetName = 'Prefix')]
@@ -110,40 +110,40 @@ Param
     [Parameter(ParameterSetName = 'Prefix')]
     [String]
     [ValidateSet('AzureADMyOrg', 'AzureADMultipleOrgs', 'AzureADandPersonalMicrosoftAccount')]
-    $signInAudience = 'AzureADMyOrg',
+    $SignInAudience = 'AzureADMyOrg',
 
     [Parameter(ParameterSetName = 'Customize')]
     [Parameter(ParameterSetName = 'Prefix')]
     [int]
-    $timeoutMin = 5,
+    $TimeoutMin = 5,
 
     [Parameter(ParameterSetName = 'Customize')]
     [Parameter(ParameterSetName = 'Prefix')]
     [string]
-    $logFile,
+    $LogFile,
 
     [Parameter(ParameterSetName = 'Customize')]
     [Parameter(ParameterSetName = 'Prefix')]
-    [Switch]$force,
+    [Switch]$Force,
 
     [Parameter(ParameterSetName = 'Customize')]
     [Parameter(ParameterSetName = 'Prefix')]
     [Switch]
-    $remove
+    $Remove
 )
 
 # load common functions
 . "$PSScriptRoot\Common.ps1"
 
-$graphAPIFormat = $global:ConfigObj.ResourceUrl + "/v1.0/" + $global:ConfigObj.TenantId + "/{0}"
+$graphAPIFormat = $global:ConfigObj.GraphAPIFormat
 $sleepSeconds = 5
 $msGraphUserReadAppId = '00000003-0000-0000-c000-000000000000'
 $msGraphUserReadId = 'e1fe6dd8-ba31-4d61-89e7-88639da4683d'
 
 function main () {
     try {
-        if ($logFile) {
-            Start-Transcript -path $logFile -Force | Out-Null
+        if ($LogFile) {
+            Start-Transcript -path $LogFile -Force | Out-Null
         }
 
         setup-Applications
@@ -152,7 +152,7 @@ function main () {
         write-errorMessage $psitem
     }
     finally {
-        if ($logFile) {
+        if ($LogFile) {
             Stop-Transcript | Out-Null
         }
     }
@@ -194,7 +194,7 @@ function add-appRegistration($WebApplicationUri, $SpaApplicationReplyUrl, $requi
     if ($AddResourceAccess) {
         $webApp = @{
             displayName            = $webApplicationName
-            signInAudience         = $signInAudience
+            signInAudience         = $SignInAudience
             identifierUris         = @($WebApplicationUri)
             defaultRedirectUri     = $SpaApplicationReplyUrl
             appRoles               = $appRole
@@ -206,7 +206,7 @@ function add-appRegistration($WebApplicationUri, $SpaApplicationReplyUrl, $requi
     else {
         $webApp = @{
             displayName        = $webApplicationName
-            signInAudience     = $signInAudience
+            signInAudience     = $SignInAudience
             identifierUris     = @($WebApplicationUri)
             defaultRedirectUri = $SpaApplicationReplyUrl
             appRoles           = $appRole
@@ -219,7 +219,7 @@ function add-appRegistration($WebApplicationUri, $SpaApplicationReplyUrl, $requi
     $webApp = invoke-graphApi -retry -uri $uri -body $webApp -method 'post'
 
     if ($webApp) {
-        $stopTime = set-stopTime $timeoutMin
+        $stopTime = set-stopTime $TimeoutMin
         
         while (!($webApp.api.oauth2PermissionScopes.gethashcode())) {
             $webApp = wait-forResult -functionPointer (get-item function:\get-appRegistration) `
@@ -253,7 +253,7 @@ function add-nativeClient($webApp, $requiredResourceAccess, $oauthPermissionsId)
             redirectUris = @("urn:ietf:wg:oauth:2.0:oob") 
         }
         displayName            = $NativeClientApplicationName
-        signInAudience         = $signInAudience
+        signInAudience         = $SignInAudience
         isFallbackPublicClient = $true
         requiredResourceAccess = $nativeAppResourceAccess
     }
@@ -365,7 +365,7 @@ function add-servicePrincipalGrantScope($clientId, $resourceId, $scope) {
     assert-notNull $result "aad app service principal oauth permissions $scope configuration failed"
 
     if ($result) {
-        $stopTime = set-stopTime $timeoutMin
+        $stopTime = set-stopTime $TimeoutMin
         $checkGrants = $null
         
         while (!$checkGrants -or !($checkGrants.scope.Contains($scope))) {
@@ -573,7 +573,7 @@ function setup-Applications() {
         })
 
     # cleanup
-    if ($remove) {
+    if ($Remove) {
         write-host "removing web service principals"
         $result = remove-servicePrincipal
     

--- a/SetupApplications.ps1
+++ b/SetupApplications.ps1
@@ -3,7 +3,7 @@
 Setup applications in a Service Fabric cluster Azure Active Directory tenant.
 
 .DESCRIPTION
-version: 2.0.2
+version: 231112
 
 Prerequisites:
 1. An Azure Active Directory tenant.

--- a/SetupApplications.ps1
+++ b/SetupApplications.ps1
@@ -37,6 +37,12 @@ Used to set metadata for specific region (for example: china, germany). Ignore i
 .PARAMETER AddResourceAccess
 Used to add the cluster applications resource access to Entra application explicitly when AAD is not able to add automatically. This may happen when the user account does not have adequate permission under this subscription.
 
+.PARAMETER AddVisualStudioAccess
+Used to add the Visual Studio MSAL client ids to the cluster application
+    'https://learn.microsoft.com/en-us/azure/service-fabric/service-fabric-manage-application-in-visual-studio'
+    Visual Studio 2022 and future versions: '04f0c124-f2bc-4f59-8241-bf6df9866bbd'
+    Visual Studio 2019 and earlier: '872cd9fa-d31f-45e0-9eab-6e460a02d1f1'
+
 .PARAMETER SignInAudience
 Sign in audience option for selection of Applicaiton AAD tenant configuration type. Default selection is 'AzureADMyOrg'
 'AzureADMyOrg', 'AzureADMultipleOrgs', 'AzureADandPersonalMicrosoftAccount'
@@ -91,7 +97,8 @@ Setup and save the setup result into a temporary variable to pass into SetupUser
 .\SetupApplications.ps1 -TenantId '4f812c74-978b-4b0e-acf5-06ffca635c0e' `
         -WebApplicationUri 'api://4f812c74-978b-4b0e-acf5-06ffca635c0e/mycluster' `
         -SpaApplicationReplyUrl 'https://mycluster.westus.cloudapp.azure.com:19080/explorer/index.html' `
-        -AddResourceAccess 
+        -AddResourceAccess `
+        -AddVisualStudioAccess
 
 Setup tenant with explicit application settings and add explicit resource access to Entra application.
 #>
@@ -135,6 +142,11 @@ Param
     [Parameter(ParameterSetName = 'Prefix')]
     [Switch]
     $AddResourceAccess,
+
+    [Parameter(ParameterSetName = 'Customize')]
+    [Parameter(ParameterSetName = 'Prefix')]
+    [Switch]
+    $AddVisualStudioAccess,
 
     [Parameter(ParameterSetName = 'Customize')]
     [Parameter(ParameterSetName = 'Prefix')]
@@ -467,6 +479,41 @@ function add-servicePrincipalGrantScope($clientId, $resourceId, $scope) {
     }
 
     return $result
+}
+
+function confirm-visualStudioAccess($webApp, [guid]$oauthPermissionsId) {
+    $preAuthorizedApplications = get-preauthorizedApplications -webApp $webApp -applicationIds $visualStudioClientIds -delegatedPermissionIds @($oauthPermissionsId)
+    if ($preAuthorizedApplications) {
+        write-host "visual studio preauthorized applications already exists."
+        # todo: should we remove if $AddVisualStudioAccess is false?
+        if (!$AddVisualStudioAccess) {
+            $remove = $true
+
+            if (!$Force) {
+                $remove = (read-host "Do you want to remove visual studio preauthorized applications? (y/n)") -ieq 'y'
+            }
+
+            if ($remove) {
+                write-host "removing visual studio preauthorized applications" -ForegroundColor Yellow
+                remove-preauthorizedApplications -webApp $webApp -applicationIds $visualStudioClientIds -delegatedPermissionIds @($oauthPermissionsId)
+                return
+            }
+        }
+    }
+    else {
+        write-host "visual studio preauthorized applications do not exist."
+    }
+
+    if (!$preAuthorizedApplications -and $AddVisualStudioAccess) {
+        write-host "adding visual studio preauthorized applications" -ForegroundColor Green
+        # check / add preauthorized applications
+        $preAuthorizedApplications = add-preauthorizedApplications -webApp $webApp -applicationIds $visualStudioClientIds -delegatedPermissionIds @($oauthPermissionsId)
+        assert-notNull $preAuthorizedApplications 'Web Application preauthorized applications Failed'
+        Write-Host "Web Application preauthorized applications created: $($preAuthorizedApplications|convertto-json)"  -ForegroundColor Green
+    }
+    else {
+        write-host "visual studio preauthorized applications not do not need to be modified." -ForegroundColor Yellow
+    }
 }
 
 function get-appRegistration($WebApplicationUri) {
@@ -805,6 +852,9 @@ function setup-Applications() {
     }
     assert-notNull $oauthPermissionsId 'Web Application Oauth permissions Failed'
     Write-Host "Web Application Oauth permissions created: $($oauthPermissionsId|convertto-json)"  -ForegroundColor Green
+
+    # check / add visual studio preauthorized applications
+    confirm-visualStudioAccess -webApp $webApp -oauthPermissionsId $oauthPermissionsId
 
     # check / add servicePrincipal
     $servicePrincipal = get-servicePrincipal -webApp $webApp

--- a/SetupApplications.ps1
+++ b/SetupApplications.ps1
@@ -37,12 +37,6 @@ Used to set metadata for specific region (for example: china, germany). Ignore i
 .PARAMETER AddResourceAccess
 Used to add the cluster applications resource access to Entra application explicitly when AAD is not able to add automatically. This may happen when the user account does not have adequate permission under this subscription.
 
-.PARAMETER AddVisualStudioAccess
-Used to add the Visual Studio MSAL client ids to the cluster application
-    'https://learn.microsoft.com/en-us/azure/service-fabric/service-fabric-manage-application-in-visual-studio'
-    Visual Studio 2022 and future versions: '04f0c124-f2bc-4f59-8241-bf6df9866bbd'
-    Visual Studio 2019 and earlier: '872cd9fa-d31f-45e0-9eab-6e460a02d1f1'
-
 .PARAMETER SignInAudience
 Sign in audience option for selection of Applicaiton AAD tenant configuration type. Default selection is 'AzureADMyOrg'
 'AzureADMyOrg', 'AzureADMultipleOrgs', 'AzureADandPersonalMicrosoftAccount'
@@ -97,8 +91,7 @@ Setup and save the setup result into a temporary variable to pass into SetupUser
 .\SetupApplications.ps1 -TenantId '4f812c74-978b-4b0e-acf5-06ffca635c0e' `
         -WebApplicationUri 'api://4f812c74-978b-4b0e-acf5-06ffca635c0e/mycluster' `
         -SpaApplicationReplyUrl 'https://mycluster.westus.cloudapp.azure.com:19080/explorer/index.html' `
-        -AddResourceAccess `
-        -AddVisualStudioAccess
+        -AddResourceAccess 
 
 Setup tenant with explicit application settings and add explicit resource access to Entra application.
 #>
@@ -142,11 +135,6 @@ Param
     [Parameter(ParameterSetName = 'Prefix')]
     [Switch]
     $AddResourceAccess,
-
-    [Parameter(ParameterSetName = 'Customize')]
-    [Parameter(ParameterSetName = 'Prefix')]
-    [Switch]
-    $AddVisualStudioAccess,
 
     [Parameter(ParameterSetName = 'Customize')]
     [Parameter(ParameterSetName = 'Prefix')]
@@ -479,41 +467,6 @@ function add-servicePrincipalGrantScope($clientId, $resourceId, $scope) {
     }
 
     return $result
-}
-
-function confirm-visualStudioAccess($webApp, [guid]$oauthPermissionsId) {
-    $preAuthorizedApplications = get-preauthorizedApplications -webApp $webApp -applicationIds $visualStudioClientIds -delegatedPermissionIds @($oauthPermissionsId)
-    if ($preAuthorizedApplications) {
-        write-host "visual studio preauthorized applications already exists."
-        # todo: should we remove if $AddVisualStudioAccess is false?
-        if (!$AddVisualStudioAccess) {
-            $remove = $true
-
-            if (!$Force) {
-                $remove = (read-host "Do you want to remove visual studio preauthorized applications? (y/n)") -ieq 'y'
-            }
-
-            if ($remove) {
-                write-host "removing visual studio preauthorized applications" -ForegroundColor Yellow
-                remove-preauthorizedApplications -webApp $webApp -applicationIds $visualStudioClientIds -delegatedPermissionIds @($oauthPermissionsId)
-                return
-            }
-        }
-    }
-    else {
-        write-host "visual studio preauthorized applications do not exist."
-    }
-
-    if (!$preAuthorizedApplications -and $AddVisualStudioAccess) {
-        write-host "adding visual studio preauthorized applications" -ForegroundColor Green
-        # check / add preauthorized applications
-        $preAuthorizedApplications = add-preauthorizedApplications -webApp $webApp -applicationIds $visualStudioClientIds -delegatedPermissionIds @($oauthPermissionsId)
-        assert-notNull $preAuthorizedApplications 'Web Application preauthorized applications Failed'
-        Write-Host "Web Application preauthorized applications created: $($preAuthorizedApplications|convertto-json)"  -ForegroundColor Green
-    }
-    else {
-        write-host "visual studio preauthorized applications not do not need to be modified." -ForegroundColor Yellow
-    }
 }
 
 function get-appRegistration($WebApplicationUri) {
@@ -852,9 +805,6 @@ function setup-Applications() {
     }
     assert-notNull $oauthPermissionsId 'Web Application Oauth permissions Failed'
     Write-Host "Web Application Oauth permissions created: $($oauthPermissionsId|convertto-json)"  -ForegroundColor Green
-
-    # check / add visual studio preauthorized applications
-    confirm-visualStudioAccess -webApp $webApp -oauthPermissionsId $oauthPermissionsId
 
     # check / add servicePrincipal
     $servicePrincipal = get-servicePrincipal -webApp $webApp

--- a/SetupClusterResource.ps1
+++ b/SetupClusterResource.ps1
@@ -16,7 +16,7 @@ v 1.1
 [cmdletbinding()]
 param(
     [Parameter(ParameterSetName = 'customobj', Mandatory = $true)]
-    [hashtable]$configObj = @{},
+    [hashtable]$ConfigObj = @{},
 
     [Parameter(ParameterSetName = 'values', Mandatory = $true)]
     [string]$tenantId = '', # guid
@@ -53,12 +53,12 @@ param(
 
 $PSModuleAutoLoadingPreference = 2
 
-if ($configObj) {
-    write-host "using configobj"
-    $tenantId = $configObj.TenantId
-    $clusterApplication = $configObj.WebAppId
-    $clientApplication = $configObj.NativeClientAppId
-    $clusterName = $configObj.ClusterName
+if ($ConfigObj) {
+    write-host "using ConfigObj"
+    $tenantId = $ConfigObj.TenantId
+    $clusterApplication = $ConfigObj.WebAppId
+    $clientApplication = $ConfigObj.NativeClientAppId
+    $clusterName = $ConfigObj.ClusterName
 }
 
 $azureActiveDirectory = @{ 

--- a/SetupUser.ps1
+++ b/SetupUser.ps1
@@ -130,7 +130,7 @@ $sleepSeconds = 5
 function main () {
     try {
         if ($logFile) {
-            Start-Transcript -path $logFile -Force
+            Start-Transcript -path $logFile -Force | Out-Null
         }
 
         enable-AADUser
@@ -141,7 +141,7 @@ function main () {
     }
     finally {
         if ($logFile) {
-            Stop-Transcript
+            Stop-Transcript | Out-Null
         }
     }
 }

--- a/SetupUser.ps1
+++ b/SetupUser.ps1
@@ -44,6 +44,15 @@ Use Force switch to force removal of AAD user account if specifying -remove.
 .PARAMETER Remove
 Use Remove to remove AAD configuration and optionally user.
 
+.PARAMETER MGClientId
+Optional AAD client id for management group. If not provided, it will use default client id.
+
+.PARAMETER MGClientSecret
+Optional AAD client secret for management group.
+
+.PARAMETER MGGrantType
+Optional AAD grant type for management group. Default is 'device_code'.
+
 .EXAMPLE
 . Scripts\SetupUser.ps1 -ConfigObj $ConfigObj -UserName 'SFuser' -Password 'Test4321'
 
@@ -62,11 +71,11 @@ Setup up an admin user providing values for parameters
 Param
 (
     [Parameter(ParameterSetName = 'Setting', Mandatory = $true)]
-    [String]
+    [guid]
     $TenantId,
 
     [Parameter(ParameterSetName = 'Setting', Mandatory = $true)]
-    [String]
+    [guid]
     $WebApplicationId,
 
     [Parameter(ParameterSetName = 'Setting')]
@@ -117,11 +126,26 @@ Param
     [Parameter(ParameterSetName = 'Setting')]
     [Parameter(ParameterSetName = 'ConfigObj')]
     [Switch]
-    $Force
+    $Force,
+    
+    [Parameter(ParameterSetName = 'Setting')]
+    [Parameter(ParameterSetName = 'ConfigObj')]
+    [guid]
+    $MGClientId,
+
+    [Parameter(ParameterSetName = 'Setting')]
+    [Parameter(ParameterSetName = 'ConfigObj')]
+    [string]
+    $MGClientSecret,
+
+    [Parameter(ParameterSetName = 'Setting')]
+    [Parameter(ParameterSetName = 'ConfigObj')]
+    [string]
+    $MGGrantType
 )
 
 # load common functions
-. "$PSScriptRoot\Common.ps1"
+. "$PSScriptRoot\Common.ps1" @PSBoundParameters
 
 $graphAPIFormat = $global:ConfigObj.GraphAPIFormat
 $servicePrincipalId = $null

--- a/SetupUser.ps1
+++ b/SetupUser.ps1
@@ -98,28 +98,28 @@ Param
     [Parameter(ParameterSetName = 'Setting')]
     [Parameter(ParameterSetName = 'ConfigObj')]
     [int]
-    $timeoutMin = 5,
+    $TimeoutMin = 5,
 
     [Parameter(ParameterSetName = 'Setting')]
     [Parameter(ParameterSetName = 'ConfigObj')]
     [string]
-    $logFile,
+    $LogFile,
 
     [Parameter(ParameterSetName = 'Setting')]
     [Parameter(ParameterSetName = 'ConfigObj')]
     [Switch]
-    $remove,
+    $Remove,
 
     [Parameter(ParameterSetName = 'Setting')]
     [Parameter(ParameterSetName = 'ConfigObj')]
     [Switch]
-    $force
+    $Force
 )
 
 # load common functions
 . "$PSScriptRoot\Common.ps1"
 
-$graphAPIFormat = $global:config.ResourceUrl + "/v1.0/" + $global:config.TenantId + "/{0}"
+$graphAPIFormat = $global:ConfigObj.GraphAPIFormat
 $servicePrincipalId = $null
 $WebApplicationId = $null
 $sleepSeconds = 5
@@ -298,7 +298,7 @@ function remove-user($userName, $domain) {
         return $true
     }
 
-    if (!$force -and (read-host "removing user $userName from Azure AD. do you want to continue?[y|n]") -imatch "n") {
+    if (!$Force -and (read-host "removing user $userName from Azure AD. do you want to continue?[y|n]") -imatch "n") {
         return
     }
 
@@ -308,7 +308,7 @@ function remove-user($userName, $domain) {
     write-host "removal complete" -ForegroundColor Green
 
     if ($result) {
-        $stopTime = set-stopTime $timeoutMin
+        $stopTime = set-stopTime $TimeoutMin
 
         do {
             $deleteResult = wait-forResult -functionPointer (get-item function:\get-user) `
@@ -339,7 +339,7 @@ function setup-User() {
     $userName = set-userName
 
     # cleanup
-    if ($remove) {
+    if ($Remove) {
         return (remove-user -userName $userName -domain $domain)
     }
 

--- a/SetupUser.ps1
+++ b/SetupUser.ps1
@@ -1,6 +1,6 @@
 ﻿<#
 .SYNOPSIS
-Setup user in a Service Fabric cluster Azure Active Directory tenant.
+Setup user in a Service Fabric cluster Entra tenant.
 
 .DESCRIPTION
 This script can create 2 types of users: Admin user assigned admin app role; Read-only user assigned readonly app role.
@@ -8,7 +8,7 @@ This script can create 2 types of users: Admin user assigned admin app role; Rea
 version: 2.0.1
 
 Prerequisites:
-1. An Azure Active Directory Tenant
+1. An Entra Tenant
 2. Service Fabric web and native client applications are setup. Or run SetupApplications.ps1.
 
 .PARAMETER TenantId
@@ -35,13 +35,13 @@ Used to set metadata for specific region (for example: china). Ignore it in glob
 .PARAMETER Domain
 Domain is the verified domain being used for user account configuration.
 
-.PARAMETER timeoutMin
+.PARAMETER TimeoutMin
 Script execution retry wait timeout in minutes. Default is 5 minutes. If script times out, it can be re-executed and will continue configuration as script is idempotent.
 
-.PARAMETER force
+.PARAMETER Force
 Use Force switch to force removal of AAD user account if specifying -remove.
 
-.PARAMETER remove
+.PARAMETER Remove
 Use Remove to remove AAD configuration and optionally user.
 
 .EXAMPLE
@@ -50,7 +50,11 @@ Use Remove to remove AAD configuration and optionally user.
 Setup up a read-only user with return SetupApplications.ps1
 
 .EXAMPLE
-. Scripts\SetupUser.ps1 -TenantId '7b25ab7e-cd25-4f0c-be06-939424dc9cc9' -WebApplicationId '9bf7c6f3-53ce-4c63-8ab3-928c7bf4200b' -UserName 'SFAdmin' -Password 'Test4321' -IsAdmin
+. Scripts\SetupUser.ps1 -TenantId '7b25ab7e-cd25-4f0c-be06-939424dc9cc9' `
+        -WebApplicationId '9bf7c6f3-53ce-4c63-8ab3-928c7bf4200b' `
+        -UserName 'SFAdmin' `
+        -Password 'Test4321' `
+        -IsAdmin
 
 Setup up an admin user providing values for parameters
 #>

--- a/SetupUser.ps1
+++ b/SetupUser.ps1
@@ -130,7 +130,7 @@ $sleepSeconds = 5
 function main () {
     try {
         if ($logFile) {
-            Start-Transcript -path $logFile -Force
+            Start-Transcript -path $logFile -Force | out-null
         }
 
         enable-AADUser
@@ -141,7 +141,7 @@ function main () {
     }
     finally {
         if ($logFile) {
-            Stop-Transcript
+            Stop-Transcript | out-null
         }
     }
 }

--- a/UpdateApplication.ps1
+++ b/UpdateApplication.ps1
@@ -30,7 +30,7 @@ $global:ConfigObj = @{}
 function main () {
     try {
         if ($logFile) {
-            Start-Transcript -path $logFile -Force
+            Start-Transcript -path $logFile -Force | Out-Null
         }
 
         update-Application
@@ -41,7 +41,7 @@ function main () {
     }
     finally {
         if ($logFile) {
-            Stop-Transcript
+            Stop-Transcript | Out-Null
         }
     }
 }

--- a/UpdateApplication.ps1
+++ b/UpdateApplication.ps1
@@ -22,10 +22,8 @@ Param
 )
 
 
-$headers = $null
 . "$PSScriptRoot\Common.ps1"
-$graphAPIFormat = $resourceUrl + "/v1.0/{0}"
-$global:ConfigObj = @{}
+$graphAPIFormat = $global:ConfigObj.ResourceUrl + "/v1.0/{0}"
 
 function main () {
     try {
@@ -36,8 +34,7 @@ function main () {
         update-Application
     }
     catch [Exception] {
-        $errorString = "exception: $($psitem.Exception.Response.StatusCode.value__)`r`nexception:`r`n$($psitem.Exception.Message)`r`n$($error | out-string)`r`n$($psitem.ScriptStackTrace)"
-        write-error $errorString
+        write-errorMessage $psitem
     }
     finally {
         if ($logFile) {

--- a/UpdateApplication.ps1
+++ b/UpdateApplication.ps1
@@ -1,3 +1,37 @@
+<#
+.SYNOPSIS
+Update applications in a Service Fabric cluster Entra tenant to migrate the web redirect URIs to SPA redirect URIs.
+
+.DESCRIPTION
+version: 231112
+
+.PARAMETER WebApplicationId
+    The WebApplicationId of the application to update
+
+.PARAMETER TimeoutMin
+    The timeout in minutes for the script to run
+
+.PARAMETER HttpPort
+    The port to search for in the redirect URIs
+
+.PARAMETER LogFile
+    The path to the log file
+
+.PARAMETER TenantId
+    The tenant id of the application to update
+
+.PARAMETER WhatIf
+    The switch to run the script in whatif mode
+
+.EXAMPLE
+    .\UpdateApplication.ps1 -WebApplicationId 'https://mysftestcluster.contoso.com' `
+        -TenantId '00000000-0000-0000-0000-000000000000' `
+        -TimeoutMin 5 `
+        -HttpPort 19080 `
+        -LogFile 'C:\temp\update-app.log' `
+        -WhatIf
+
+#>
 [cmdletbinding()]
 Param
 (
@@ -12,7 +46,7 @@ Param
     $HttpPort = 19080,
     [Parameter(ParameterSetName = 'Customize')]
     [string]
-    $logFile,
+    $LogFile,
     [Parameter(ParameterSetName = 'Customize', Mandatory = $true)]
     [String]
     $TenantId,
@@ -27,8 +61,8 @@ $graphAPIFormat = $global:ConfigObj.GraphAPIFormat
 
 function main () {
     try {
-        if ($logFile) {
-            Start-Transcript -path $logFile -Force | Out-Null
+        if ($LogFile) {
+            Start-Transcript -path $LogFile -Force | Out-Null
         }
 
         update-Application
@@ -37,7 +71,7 @@ function main () {
         write-errorMessage $psitem
     }
     finally {
-        if ($logFile) {
+        if ($LogFile) {
             Stop-Transcript | Out-Null
         }
     }

--- a/UpdateApplication.ps1
+++ b/UpdateApplication.ps1
@@ -6,7 +6,7 @@ Param
     $WebApplicationId,
     [Parameter(ParameterSetName = 'Customize')]
     [int]
-    $timeoutMin = 5,
+    $TimeoutMin = 5,
     [Parameter(ParameterSetName = 'Customize')]
     [int]
     $HttpPort = 19080,
@@ -21,9 +21,9 @@ Param
     $WhatIf
 )
 
-
+# load common functions
 . "$PSScriptRoot\Common.ps1"
-$graphAPIFormat = $global:ConfigObj.ResourceUrl + "/v1.0/{0}"
+$graphAPIFormat = $global:ConfigObj.GraphAPIFormat
 
 function main () {
     try {

--- a/test-aad-setup.ps1
+++ b/test-aad-setup.ps1
@@ -4,21 +4,21 @@ test sf aad scripts
 #>
 param(
     [parameter(Mandatory = $true)]
-    $resourceGroupName,
-    $tenantId = "$((get-azcontext).tenant.id)",
-    $clusterName = $resourceGroupName,
+    [string]$resourceGroupName,
+    [string]$tenantId = "$((get-azcontext).tenant.id)",
+    [string]$clusterName = $resourceGroupName,
+    [string]$translog = "$pwd/tran-$($startTime.tostring('yyMMddhhmmss')).log",
     [switch]$setupReadonlyUser,
     [switch]$setupAdminUser,
     [switch]$setupClusterResource,
-    [switch]$enableVisualStudioAccess,
     [switch]$remove,
-    [switch]$force
+    [switch]$force,
+    [switch]$addVisualStudioAccess
 )
 
 $errorActionPreference = 'continue'
 $curDir = $pwd
 $startTime = get-date
-#$translog = "$pwd/tran-$($startTime.tostring('yyMMddhhmmss')).log"
 
 try {
     write-host "$(get-date) starting transcript $translog"
@@ -37,9 +37,9 @@ try {
         -ClusterName $clusterName ``
         -SpaApplicationReplyUrl $replyUrl ``
         -AddResourceAccess ``
-        -AddVisualStudioAccess:`$$enableVisualStudioAccess ``
         -WebApplicationUri $webApplicationUri ``
         -logFile $translog ``
+        -AddVisualStudioAccess:`$$addVisualStudioAccess ``
         -Verbose ``
         -force:`$$force ``
         -remove:`$$remove
@@ -49,8 +49,8 @@ try {
         -ClusterName $clusterName `
         -SpaApplicationReplyUrl $replyUrl `
         -AddResourceAccess `
-        -AddVisualStudioAccess:$enableVisualStudioAccess `
         -WebApplicationUri $webApplicationUri `
+        -AddVisualStudioAccess:$addVisualStudioAccess `
         -logFile $translog `
         -Verbose `
         -force:$force `

--- a/test-aad-setup.ps1
+++ b/test-aad-setup.ps1
@@ -10,7 +10,8 @@ param(
     $clusterName = $resourceGroupName,
     [switch]$remove,
     [switch]$force,
-    [switch]$noClusterResourceSetup
+    [switch]$noClusterResourceSetup,
+    [switch]$addVisualStudioAccess
 )
 
 $errorActionPreference = 'continue'
@@ -34,9 +35,11 @@ try {
         -ClusterName $clusterName ``
         -SpaApplicationReplyUrl $replyUrl ``
         -AddResourceAccess ``
+        -AddVisualStudioAccess:$addVisualStudioAccess ``
         -WebApplicationUri $webApplicationUri ``
         -logFile $translog ``
         -Verbose ``
+        -force:$force ``
         -remove:$remove
     " -ForegroundColor Cyan
 
@@ -44,9 +47,11 @@ try {
         -ClusterName $clusterName `
         -SpaApplicationReplyUrl $replyUrl `
         -AddResourceAccess `
+        -AddVisualStudioAccess:$addVisualStudioAccess `
         -WebApplicationUri $webApplicationUri `
         -logFile $translog `
         -Verbose `
+        -force:$force `
         -remove:$remove
 
     write-host "ConfigObj:" -ForegroundColor Cyan

--- a/test-aad-setup.ps1
+++ b/test-aad-setup.ps1
@@ -1,0 +1,69 @@
+<#
+test sf aad scripts
+place in clouddrive dir in shell.azure.com
+
+#>
+param(
+    [parameter(Mandatory = $true)]
+    $resourceGroupName,
+    $tenantId = "$((get-azcontext).tenant.id)",
+    $clusterName = $resourceGroupName,
+    [switch]$remove,
+    [switch]$force
+)
+
+$errorActionPreference = 'continue'
+$curDir = $pwd
+$startTime = get-date
+$translog = "$pwd/tran-$($startTime.tostring('yyMMddhhmmss')).log"
+
+try {
+    write-host "$(get-date) starting transcript $translog"
+    $location = (get-azResourceGroup -Name $resourceGroupName).location
+    if (!$location) {
+        throw "resource group $resourceGroupName not found"
+    }
+
+    $replyUrl = "https://$clusterName.$location.cloudapp.azure.com:19080/Explorer/index.html" # <--- client browser redirect url
+
+    #$webApplicationUri = 'https://mysftestcluster.contoso.com' # <--- must be verified domain due to AAD changes
+    $webApplicationUri = "api://$tenantId/$clusterName" # <--- does not have to be verified domain
+
+    $ConfigObj = .\SetupApplications.ps1 -TenantId $tenantId `
+        -ClusterName $clusterName `
+        -SpaApplicationReplyUrl $replyUrl `
+        -AddResourceAccess `
+        -WebApplicationUri $webApplicationUri `
+        -logFile $translog `
+        -Verbose `
+        -remove:$remove
+
+    #write-host $ConfigObj
+    $ConfigObj
+
+    .\SetupUser.ps1 -ConfigObj $ConfigObj `
+        -UserName 'TestUser' `
+        -Password 'P@ssword!123' `
+        -Verbose `
+        -logFile $translog `
+        -remove:$remove `
+        -force:$force
+
+    .\SetupUser.ps1 -ConfigObj $ConfigObj `
+        -UserName 'TestAdmin' `
+        -Password 'P@ssword!123' `
+        -IsAdmin `
+        -Verbose `
+        -logFile $translog `
+        -remove:$remove `
+        -force:$force
+
+    .\SetupClusterResource.ps1 -configObj $ConfigObj `
+        -resourceGroupName $resourceGroupName
+
+}
+finally {
+    write-host "$(get-date) stopping transcript $translog"
+    #stop-transcript
+    set-location $curDir
+}

--- a/test-aad-setup.ps1
+++ b/test-aad-setup.ps1
@@ -1,6 +1,55 @@
 <#
-test sf aad scripts
+.SYNOPSIS
+    script used to test entra / aad setup scripts for service fabric cluster with aad integration enabled
+.DESCRIPTION
+    script used to test entra / aad setup scriptis for service fabric cluster with aad integration enabled.
+    requires test service fabric cluster
+    requires admin access to azure ad / entra / graph
 
+    Typical usage: .\test-aad-setup.ps1 -resourceGroupName 'myrg' -clusterName 'mysfcluster' -setupReadonlyUser -setupAdminUser -setupClusterResource -addVisualStudioAccess
+        executes: .\SetupApplications.ps1 -TenantId $tenantId -ClusterName $clusterName -SpaApplicationReplyUrl $replyUrl -AddResourceAccess -WebApplicationUri $webApplicationUri -AddVisualStudioAccess:$addVisualStudioAccess -logFile $translog -Verbose -force:$force -remove:$remove
+        executes: .\SetupUser.ps1 -ConfigObj $ConfigObj -UserName 'TestReadOnly' -Password 'P@ssword!123' -IsReadOnly -Verbose -logFile $translog -remove:$remove -force:$force
+        executes: .\SetupUser.ps1 -ConfigObj $ConfigObj -UserName 'TestAdmin' -Password 'P@ssword!123' -IsAdmin -Verbose -logFile $translog -remove:$remove -force:$force
+        executes: .\SetupClusterResource.ps1 -resourceGroupName $resourceGroupName -ConfigObj $($ConfigObj | convertto-json -depth 99)
+
+.EXAMPLE
+    .\test-aad-setup.ps1 -resourceGroupName 'myrg'
+.EXAMPLE
+    .\test-aad-setup.ps1 -resourceGroupName 'myrg' -clusterName 'mysfcluster'
+.EXAMPLE
+    .\test-aad-setup.ps1 -resourceGroupName 'myrg' -clusterName 'mysfcluster' -setupReadonlyUser
+.EXAMPLE
+    .\test-aad-setup.ps1 -resourceGroupName 'myrg' -clusterName 'mysfcluster' -setupReadonlyUser -setupAdminUser
+.EXAMPLE
+    .\test-aad-setup.ps1 -resourceGroupName 'myrg' -clusterName 'mysfcluster' -setupReadonlyUser -setupAdminUser -setupClusterResource
+.EXAMPLE
+    .\test-aad-setup.ps1 -resourceGroupName 'myrg' -clusterName 'mysfcluster' -setupReadonlyUser -setupAdminUser -setupClusterResource -addVisualStudioAccess
+.EXAMPLE
+    .\test-aad-setup.ps1 -resourceGroupName 'myrg' -clusterName 'mysfcluster' -setupReadonlyUser -setupAdminUser -setupClusterResource -addVisualStudioAccess -MGClientId '14d82eec-204b-4c2f-b7e8-296a70dab67e' -MGClientSecret 'mysecret'
+.PARAMETER resourceGroupName
+    resource group name of the test cluster
+.PARAMETER tenantId
+    tenant id for resource group. defaults to current az context tenant id
+.PARAMETER clusterName
+    test cluster name if different than resource group name
+.PARAMETER setupReadonlyUser
+    setup readonly user 'TestReadOnly' with read only access to cluster
+.PARAMETER setupAdminUser
+    setup test admin user 'TestAdmin' with read / write access to cluster
+.PARAMETER setupClusterResource
+    setup cluster resource with new application registration client id
+.PARAMETER addVisualStudioAccess
+    add visual studio application registration ids to the cluster resource for deployment access from visual studio
+.PARAMETER remove
+    remove
+.PARAMETER force
+    force
+.PARAMETER MGClientId
+    optional Microsoft Graph Client Id if not using default
+.PARAMETER MGClientSecret
+    optional Microsoft Graph Client Secret
+.PARAMETER MGGrantType
+    optional Microsoft Graph Grant Type (default: urn:ietf:params:oauth:grant-type:device_code)
 #>
 param(
     [parameter(Mandatory = $true)]
@@ -35,13 +84,13 @@ function main() {
 
         #$webApplicationUri = 'https://mysftestcluster.contoso.com' # <--- must be verified domain due to AAD changes
         $webApplicationUri = "api://$tenantId/$clusterName" # <--- does not have to be verified domain
-            
+
         if ($MGClientSecret) {
             setup-applicationMG
 
             write-host "ConfigObj:" -ForegroundColor Cyan
             $ConfigObj
-    
+
             if ($setupReadonlyUser) {
                 setup-readOnlyUserMG
             }
@@ -51,14 +100,14 @@ function main() {
 
             write-host "ConfigObj:" -ForegroundColor Cyan
             $ConfigObj
-    
+
         }
         else {
             setup-application
 
             write-host "ConfigObj:" -ForegroundColor Cyan
             $ConfigObj
-    
+
             if ($setupReadonlyUser) {
                 setup-readOnlyUser
             }
@@ -68,9 +117,9 @@ function main() {
 
             write-host "ConfigObj:" -ForegroundColor Cyan
             $ConfigObj
-    
+
         }
-    
+
         if ($setupClusterResource) {
             write-host ".\SetupClusterResource.ps1 -resourceGroupName $resourceGroupName
             -ConfigObj $($ConfigObj | convertto-json -depth 99)
@@ -156,7 +205,7 @@ function setup-readOnlyUser() {
     -force:`$$force
     -ConfigObj $($ConfigObj | convertto-json -depth 99)
 " -ForegroundColor Cyan
-    
+
     .\SetupUser.ps1 -ConfigObj $ConfigObj `
         -UserName 'TestReadOnly' `
         -Password 'P@ssword!123' `
@@ -182,7 +231,7 @@ function setup-readOnlyUserMG() {
     -MGClientSecret $MGClientSecret `
     -MGGrantType $MGGrantType
 " -ForegroundColor Cyan
-        
+
     .\SetupUser.ps1 -ConfigObj $ConfigObj `
         -UserName 'TestReadOnly' `
         -Password 'P@ssword!123' `
@@ -208,7 +257,7 @@ function setup-adminUser() {
     -force:`$$force
     -ConfigObj $($ConfigObj | convertto-json -depth 99)
 " -ForegroundColor Cyan
-    
+
     .\SetupUser.ps1 -ConfigObj $ConfigObj `
         -UserName 'TestAdmin' `
         -Password 'P@ssword!123' `
@@ -234,7 +283,7 @@ function setup-adminUserMG() {
     -MGClientSecret $MGClientSecret `
     -MGGrantType $MGGrantType
 " -ForegroundColor Cyan
-    
+
     .\SetupUser.ps1 -ConfigObj $ConfigObj `
         -UserName 'TestAdmin' `
         -Password 'P@ssword!123' `

--- a/test-aad-setup.ps1
+++ b/test-aad-setup.ps1
@@ -7,43 +7,97 @@ param(
     [string]$resourceGroupName,
     [string]$tenantId = "$((get-azcontext).tenant.id)",
     [string]$clusterName = $resourceGroupName,
-    [string]$translog = "$pwd/tran-$($startTime.tostring('yyMMddhhmmss')).log",
     [switch]$setupReadonlyUser,
     [switch]$setupAdminUser,
     [switch]$setupClusterResource,
     [switch]$remove,
     [switch]$force,
-    [switch]$addVisualStudioAccess
+    [switch]$addVisualStudioAccess,
+    [guid]$MGClientId = '14d82eec-204b-4c2f-b7e8-296a70dab67e', # well-known ps graph client id generated on connect
+    [string]$MGClientSecret = $null,
+    [string]$MGGrantType = 'urn:ietf:params:oauth:grant-type:device_code' #'client_credentials', #'authorization_code'
 )
 
 $errorActionPreference = 'continue'
 $curDir = $pwd
 $startTime = get-date
+$replyUrl = ""
+$webApplicationUri = ""
 
-try {
-    write-host "$(get-date) starting transcript $translog"
-    $location = (get-azResourceGroup -Name $resourceGroupName).location
-    if (!$location) {
-        throw "resource group $resourceGroupName not found"
-    }
+function main() {
+    try {
 
-    $replyUrl = "https://$clusterName.$location.cloudapp.azure.com:19080/Explorer/index.html" # <--- client browser redirect url
+        $location = (get-azResourceGroup -Name $resourceGroupName).location
+        if (!$location) {
+            throw "resource group $resourceGroupName not found"
+        }
+        $replyUrl = "https://$clusterName.$location.cloudapp.azure.com:19080/Explorer/index.html" # <--- client browser redirect url
 
-    #$webApplicationUri = 'https://mysftestcluster.contoso.com' # <--- must be verified domain due to AAD changes
-    $webApplicationUri = "api://$tenantId/$clusterName" # <--- does not have to be verified domain
+        #$webApplicationUri = 'https://mysftestcluster.contoso.com' # <--- must be verified domain due to AAD changes
+        $webApplicationUri = "api://$tenantId/$clusterName" # <--- does not have to be verified domain
+            
+        if ($MGClientSecret) {
+            setup-applicationMG
+
+            write-host "ConfigObj:" -ForegroundColor Cyan
+            $ConfigObj
     
+            if ($setupReadonlyUser) {
+                setup-readOnlyUserMG
+            }
+            if ($setupAdminUser) {
+                setup-adminUserMG
+            }
+
+            write-host "ConfigObj:" -ForegroundColor Cyan
+            $ConfigObj
+    
+        }
+        else {
+            setup-application
+
+            write-host "ConfigObj:" -ForegroundColor Cyan
+            $ConfigObj
+    
+            if ($setupReadonlyUser) {
+                setup-readOnlyUser
+            }
+            if ($setupAdminUser) {
+                setup-adminUser
+            }
+
+            write-host "ConfigObj:" -ForegroundColor Cyan
+            $ConfigObj
+    
+        }
+    
+        if ($setupClusterResource) {
+            write-host ".\SetupClusterResource.ps1 -resourceGroupName $resourceGroupName
+            -ConfigObj $($ConfigObj | convertto-json -depth 99)
+        " -ForegroundColor Cyan
+
+            .\SetupClusterResource.ps1 -configObj $ConfigObj -resourceGroupName $resourceGroupName
+        }
+    }
+    finally {
+        set-location $curDir
+    }
+}
+
+function setup-application() {
     $translog = "$pwd/setup-application-$($startTime.tostring('yyMMddhhmmss')).log"
+
     write-host ".\SetupApplications.ps1 -TenantId $tenantId ``
-        -ClusterName $clusterName ``
-        -SpaApplicationReplyUrl $replyUrl ``
-        -AddResourceAccess ``
-        -WebApplicationUri $webApplicationUri ``
-        -logFile $translog ``
-        -AddVisualStudioAccess:`$$addVisualStudioAccess ``
-        -Verbose ``
-        -force:`$$force ``
-        -remove:`$$remove
-    " -ForegroundColor Cyan
+    -ClusterName $clusterName ``
+    -SpaApplicationReplyUrl $replyUrl ``
+    -AddResourceAccess ``
+    -WebApplicationUri $webApplicationUri ``
+    -logFile $translog ``
+    -AddVisualStudioAccess:`$$addVisualStudioAccess ``
+    -Verbose ``
+    -force:`$$force ``
+    -remove:`$$remove
+" -ForegroundColor Cyan
 
     $ConfigObj = .\SetupApplications.ps1 -TenantId $tenantId `
         -ClusterName $clusterName `
@@ -55,62 +109,143 @@ try {
         -Verbose `
         -force:$force `
         -remove:$remove
-
-    write-host "ConfigObj:" -ForegroundColor Cyan
-    $ConfigObj
-
-    if ($setupReadonlyUser) {
-        $translog = "$pwd/setup-testuser-$($startTime.tostring('yyMMddhhmmss')).log"
-        write-host ".\SetupUser.ps1 -UserName 'TestUser' ``
-        -Password 'P@ssword!123' ``
-        -Verbose ``
-        -logFile $translog ``
-        -remove:`$$remove ``
-        -force:`$$force ``
-        -ConfigObj $($ConfigObj | convertto-json -depth 99)
-    " -ForegroundColor Cyan
-
-        .\SetupUser.ps1 -ConfigObj $ConfigObj `
-            -UserName 'TestUser' `
-            -Password 'P@ssword!123' `
-            -Verbose `
-            -logFile $translog `
-            -remove:$remove `
-            -force:$force
-    }
-    
-    if ($setupAdminUser) {
-        $translog = "$pwd/setup-testadmin-$($startTime.tostring('yyMMddhhmmss')).log"
-        write-host ".\SetupUser.ps1 -UserName 'TestAdmin' ``
-            -Password 'P@ssword!123' ``
-            -IsAdmin ``
-            -Verbose ``
-            -logFile $translog ``
-            -remove:`$$remove ``
-            -force:`$$force
-            -ConfigObj $($ConfigObj | convertto-json -depth 99)
-        " -ForegroundColor Cyan
-    
-        .\SetupUser.ps1 -ConfigObj $ConfigObj `
-            -UserName 'TestAdmin' `
-            -Password 'P@ssword!123' `
-            -IsAdmin `
-            -Verbose `
-            -logFile $translog `
-            -remove:$remove `
-            -force:$force    
-    }
-
-    if ($setupClusterResource) {
-        write-host ".\SetupClusterResource.ps1 -resourceGroupName $resourceGroupName
-            -ConfigObj $($ConfigObj | convertto-json -depth 99)
-        " -ForegroundColor Cyan
-
-        .\SetupClusterResource.ps1 -configObj $ConfigObj -resourceGroupName $resourceGroupName
-    }
 }
-finally {
-    write-host "$(get-date) stopping transcript $translog"
-    #stop-transcript
-    set-location $curDir
+
+function setup-applicationMG() {
+    $translog = "$pwd/setup-application-$($startTime.tostring('yyMMddhhmmss')).log"
+
+    write-host ".\SetupApplications.ps1 -TenantId $tenantId ``
+    -ClusterName $clusterName ``
+    -SpaApplicationReplyUrl $replyUrl ``
+    -AddResourceAccess ``
+    -WebApplicationUri $webApplicationUri ``
+    -logFile $translog ``
+    -AddVisualStudioAccess:`$$addVisualStudioAccess ``
+    -Verbose ``
+    -force:`$$force ``
+    -remove:`$$remove ``
+    -MGClientId $MGClientId ``
+    -MGClientSecret $MGClientSecret ``
+    -MGGrantType $MGGrantType
+" -ForegroundColor Cyan
+
+    $ConfigObj = .\SetupApplications.ps1 -TenantId $tenantId `
+        -ClusterName $clusterName `
+        -SpaApplicationReplyUrl $replyUrl `
+        -AddResourceAccess `
+        -WebApplicationUri $webApplicationUri `
+        -AddVisualStudioAccess:$addVisualStudioAccess `
+        -logFile $translog `
+        -Verbose `
+        -force:$force `
+        -remove:$remove `
+        -MGClientId $MGClientId `
+        -MGClientSecret $MGClientSecret `
+        -MGGrantType $MGGrantType
 }
+
+function setup-readOnlyUser() {
+    $translog = "$pwd/setup-readonly-$($startTime.tostring('yyMMddhhmmss')).log"
+
+    write-host ".\SetupUser.ps1 -UserName 'TestReadOnly' ``
+    -Password 'P@ssword!123' ``
+    -IsReadOnly ``
+    -Verbose ``
+    -logFile $translog ``
+    -remove:`$$remove ``
+    -force:`$$force
+    -ConfigObj $($ConfigObj | convertto-json -depth 99)
+" -ForegroundColor Cyan
+    
+    .\SetupUser.ps1 -ConfigObj $ConfigObj `
+        -UserName 'TestReadOnly' `
+        -Password 'P@ssword!123' `
+        -IsReadOnly `
+        -Verbose `
+        -logFile $translog `
+        -remove:$remove `
+        -force:$force
+}
+
+function setup-readOnlyUserMG() {
+    $translog = "$pwd/setup-readonly-$($startTime.tostring('yyMMddhhmmss')).log"
+
+    write-host ".\SetupUser.ps1 -UserName 'TestReadOnly' ``
+    -Password 'P@ssword!123' ``
+    -IsReadOnly ``
+    -Verbose ``
+    -logFile $translog ``
+    -remove:`$$remove ``
+    -force:`$$force
+    -ConfigObj $($ConfigObj | convertto-json -depth 99)
+    -MGClientId $MGClientId `
+    -MGClientSecret $MGClientSecret `
+    -MGGrantType $MGGrantType
+" -ForegroundColor Cyan
+        
+    .\SetupUser.ps1 -ConfigObj $ConfigObj `
+        -UserName 'TestReadOnly' `
+        -Password 'P@ssword!123' `
+        -IsReadOnly `
+        -Verbose `
+        -logFile $translog `
+        -remove:$remove `
+        -force:$force `
+        -MGClientId $MGClientId `
+        -MGClientSecret $MGClientSecret `
+        -MGGrantType $MGGrantType
+}
+
+function setup-adminUser() {
+    $translog = "$pwd/setup-admin-$($startTime.tostring('yyMMddhhmmss')).log"
+
+    write-host ".\SetupUser.ps1 -UserName 'TestAdmin' ``
+    -Password 'P@ssword!123' ``
+    -IsAdmin ``
+    -Verbose ``
+    -logFile $translog ``
+    -remove:`$$remove ``
+    -force:`$$force
+    -ConfigObj $($ConfigObj | convertto-json -depth 99)
+" -ForegroundColor Cyan
+    
+    .\SetupUser.ps1 -ConfigObj $ConfigObj `
+        -UserName 'TestAdmin' `
+        -Password 'P@ssword!123' `
+        -IsAdmin `
+        -Verbose `
+        -logFile $translog `
+        -remove:$remove `
+        -force:$force
+}
+
+function setup-adminUserMG() {
+    $translog = "$pwd/setup-admin-$($startTime.tostring('yyMMddhhmmss')).log"
+
+    write-host ".\SetupUser.ps1 -UserName 'TestAdmin' ``
+    -Password 'P@ssword!123' ``
+    -IsAdmin ``
+    -Verbose ``
+    -logFile $translog ``
+    -remove:`$$remove ``
+    -force:`$$force
+    -ConfigObj $($ConfigObj | convertto-json -depth 99)
+    -MGClientId $MGClientId `
+    -MGClientSecret $MGClientSecret `
+    -MGGrantType $MGGrantType
+" -ForegroundColor Cyan
+    
+    .\SetupUser.ps1 -ConfigObj $ConfigObj `
+        -UserName 'TestAdmin' `
+        -Password 'P@ssword!123' `
+        -IsAdmin `
+        -Verbose `
+        -logFile $translog `
+        -remove:$remove `
+        -force:$force `
+        -MGClientId $MGClientId `
+        -MGClientSecret $MGClientSecret `
+        -MGGrantType $MGGrantType
+}
+
+main

--- a/test-aad-setup.ps1
+++ b/test-aad-setup.ps1
@@ -6,8 +6,8 @@
     requires test service fabric cluster
     requires admin access to azure ad / entra / graph
 
-    Typical usage: .\test-aad-setup.ps1 -resourceGroupName 'myrg' -clusterName 'mysfcluster' -setupReadonlyUser -setupAdminUser -setupClusterResource -addVisualStudioAccess
-        executes: .\SetupApplications.ps1 -TenantId $tenantId -ClusterName $clusterName -SpaApplicationReplyUrl $replyUrl -AddResourceAccess -WebApplicationUri $webApplicationUri -AddVisualStudioAccess:$addVisualStudioAccess -logFile $translog -Verbose -force:$force -remove:$remove
+    Typical usage: .\test-aad-setup.ps1 -resourceGroupName 'myrg' -clusterName 'mysfcluster' -setupReadonlyUser -setupAdminUser -setupClusterResource
+        executes: .\SetupApplications.ps1 -TenantId $tenantId -ClusterName $clusterName -SpaApplicationReplyUrl $replyUrl -AddResourceAccess -WebApplicationUri $webApplicationUri -logFile $translog -Verbose -force:$force -remove:$remove
         executes: .\SetupUser.ps1 -ConfigObj $ConfigObj -UserName 'TestReadOnly' -Password 'P@ssword!123' -IsReadOnly -Verbose -logFile $translog -remove:$remove -force:$force
         executes: .\SetupUser.ps1 -ConfigObj $ConfigObj -UserName 'TestAdmin' -Password 'P@ssword!123' -IsAdmin -Verbose -logFile $translog -remove:$remove -force:$force
         executes: .\SetupClusterResource.ps1 -resourceGroupName $resourceGroupName -ConfigObj $($ConfigObj | convertto-json -depth 99)
@@ -22,10 +22,6 @@
     .\test-aad-setup.ps1 -resourceGroupName 'myrg' -clusterName 'mysfcluster' -setupReadonlyUser -setupAdminUser
 .EXAMPLE
     .\test-aad-setup.ps1 -resourceGroupName 'myrg' -clusterName 'mysfcluster' -setupReadonlyUser -setupAdminUser -setupClusterResource
-.EXAMPLE
-    .\test-aad-setup.ps1 -resourceGroupName 'myrg' -clusterName 'mysfcluster' -setupReadonlyUser -setupAdminUser -setupClusterResource -addVisualStudioAccess
-.EXAMPLE
-    .\test-aad-setup.ps1 -resourceGroupName 'myrg' -clusterName 'mysfcluster' -setupReadonlyUser -setupAdminUser -setupClusterResource -addVisualStudioAccess -MGClientId '14d82eec-204b-4c2f-b7e8-296a70dab67e' -MGClientSecret 'mysecret'
 .PARAMETER resourceGroupName
     resource group name of the test cluster
 .PARAMETER tenantId
@@ -38,8 +34,6 @@
     setup test admin user 'TestAdmin' with read / write access to cluster
 .PARAMETER setupClusterResource
     setup cluster resource with new application registration client id
-.PARAMETER addVisualStudioAccess
-    add visual studio application registration ids to the cluster resource for deployment access from visual studio
 .PARAMETER remove
     remove
 .PARAMETER force
@@ -61,7 +55,6 @@ param(
     [switch]$setupClusterResource,
     [switch]$remove,
     [switch]$force,
-    [switch]$addVisualStudioAccess,
     [guid]$MGClientId = '14d82eec-204b-4c2f-b7e8-296a70dab67e', # well-known ps graph client id generated on connect
     [string]$MGClientSecret = $null,
     [string]$MGGrantType = 'urn:ietf:params:oauth:grant-type:device_code' #'client_credentials', #'authorization_code'
@@ -142,7 +135,6 @@ function setup-application() {
     -AddResourceAccess ``
     -WebApplicationUri $webApplicationUri ``
     -logFile $translog ``
-    -AddVisualStudioAccess:`$$addVisualStudioAccess ``
     -Verbose ``
     -force:`$$force ``
     -remove:`$$remove
@@ -153,7 +145,6 @@ function setup-application() {
         -SpaApplicationReplyUrl $replyUrl `
         -AddResourceAccess `
         -WebApplicationUri $webApplicationUri `
-        -AddVisualStudioAccess:$addVisualStudioAccess `
         -logFile $translog `
         -Verbose `
         -force:$force `
@@ -169,7 +160,6 @@ function setup-applicationMG() {
     -AddResourceAccess ``
     -WebApplicationUri $webApplicationUri ``
     -logFile $translog ``
-    -AddVisualStudioAccess:`$$addVisualStudioAccess ``
     -Verbose ``
     -force:`$$force ``
     -remove:`$$remove ``
@@ -183,7 +173,6 @@ function setup-applicationMG() {
         -SpaApplicationReplyUrl $replyUrl `
         -AddResourceAccess `
         -WebApplicationUri $webApplicationUri `
-        -AddVisualStudioAccess:$addVisualStudioAccess `
         -logFile $translog `
         -Verbose `
         -force:$force `

--- a/test-aad-setup.ps1
+++ b/test-aad-setup.ps1
@@ -6,8 +6,8 @@
     requires test service fabric cluster
     requires admin access to azure ad / entra / graph
 
-    Typical usage: .\test-aad-setup.ps1 -resourceGroupName 'myrg' -clusterName 'mysfcluster' -setupReadonlyUser -setupAdminUser -setupClusterResource
-        executes: .\SetupApplications.ps1 -TenantId $tenantId -ClusterName $clusterName -SpaApplicationReplyUrl $replyUrl -AddResourceAccess -WebApplicationUri $webApplicationUri -logFile $translog -Verbose -force:$force -remove:$remove
+    Typical usage: .\test-aad-setup.ps1 -resourceGroupName 'myrg' -clusterName 'mysfcluster' -setupReadonlyUser -setupAdminUser -setupClusterResource -addVisualStudioAccess
+        executes: .\SetupApplications.ps1 -TenantId $tenantId -ClusterName $clusterName -SpaApplicationReplyUrl $replyUrl -AddResourceAccess -WebApplicationUri $webApplicationUri -AddVisualStudioAccess:$addVisualStudioAccess -logFile $translog -Verbose -force:$force -remove:$remove
         executes: .\SetupUser.ps1 -ConfigObj $ConfigObj -UserName 'TestReadOnly' -Password 'P@ssword!123' -IsReadOnly -Verbose -logFile $translog -remove:$remove -force:$force
         executes: .\SetupUser.ps1 -ConfigObj $ConfigObj -UserName 'TestAdmin' -Password 'P@ssword!123' -IsAdmin -Verbose -logFile $translog -remove:$remove -force:$force
         executes: .\SetupClusterResource.ps1 -resourceGroupName $resourceGroupName -ConfigObj $($ConfigObj | convertto-json -depth 99)
@@ -22,6 +22,10 @@
     .\test-aad-setup.ps1 -resourceGroupName 'myrg' -clusterName 'mysfcluster' -setupReadonlyUser -setupAdminUser
 .EXAMPLE
     .\test-aad-setup.ps1 -resourceGroupName 'myrg' -clusterName 'mysfcluster' -setupReadonlyUser -setupAdminUser -setupClusterResource
+.EXAMPLE
+    .\test-aad-setup.ps1 -resourceGroupName 'myrg' -clusterName 'mysfcluster' -setupReadonlyUser -setupAdminUser -setupClusterResource -addVisualStudioAccess
+.EXAMPLE
+    .\test-aad-setup.ps1 -resourceGroupName 'myrg' -clusterName 'mysfcluster' -setupReadonlyUser -setupAdminUser -setupClusterResource -addVisualStudioAccess -MGClientId '14d82eec-204b-4c2f-b7e8-296a70dab67e' -MGClientSecret 'mysecret'
 .PARAMETER resourceGroupName
     resource group name of the test cluster
 .PARAMETER tenantId
@@ -34,6 +38,8 @@
     setup test admin user 'TestAdmin' with read / write access to cluster
 .PARAMETER setupClusterResource
     setup cluster resource with new application registration client id
+.PARAMETER addVisualStudioAccess
+    add visual studio application registration ids to the cluster resource for deployment access from visual studio
 .PARAMETER remove
     remove
 .PARAMETER force
@@ -55,6 +61,7 @@ param(
     [switch]$setupClusterResource,
     [switch]$remove,
     [switch]$force,
+    [switch]$addVisualStudioAccess,
     [guid]$MGClientId = '14d82eec-204b-4c2f-b7e8-296a70dab67e', # well-known ps graph client id generated on connect
     [string]$MGClientSecret = $null,
     [string]$MGGrantType = 'urn:ietf:params:oauth:grant-type:device_code' #'client_credentials', #'authorization_code'
@@ -135,6 +142,7 @@ function setup-application() {
     -AddResourceAccess ``
     -WebApplicationUri $webApplicationUri ``
     -logFile $translog ``
+    -AddVisualStudioAccess:`$$addVisualStudioAccess ``
     -Verbose ``
     -force:`$$force ``
     -remove:`$$remove
@@ -145,6 +153,7 @@ function setup-application() {
         -SpaApplicationReplyUrl $replyUrl `
         -AddResourceAccess `
         -WebApplicationUri $webApplicationUri `
+        -AddVisualStudioAccess:$addVisualStudioAccess `
         -logFile $translog `
         -Verbose `
         -force:$force `
@@ -160,6 +169,7 @@ function setup-applicationMG() {
     -AddResourceAccess ``
     -WebApplicationUri $webApplicationUri ``
     -logFile $translog ``
+    -AddVisualStudioAccess:`$$addVisualStudioAccess ``
     -Verbose ``
     -force:`$$force ``
     -remove:`$$remove ``
@@ -173,6 +183,7 @@ function setup-applicationMG() {
         -SpaApplicationReplyUrl $replyUrl `
         -AddResourceAccess `
         -WebApplicationUri $webApplicationUri `
+        -AddVisualStudioAccess:$addVisualStudioAccess `
         -logFile $translog `
         -Verbose `
         -force:$force `


### PR DESCRIPTION
## Purpose
- Add test script with parameter descriptions and examples
- Add parameter descriptions to scripts
- Add additional logging in .\common.ps1 for get-RESTHeader*
- Add support for custom MS Graph client ID and type if not using default graph application id:
	- $MGClientId
	- $MGClientSecret
	- $MGGrantType
- Standardize parameter names and case across scripts
- Add get-preauthorizedApplications -remote to check for existing configuration in azure vs local config
- Add new switch  -AddVisualStudioAccess to add wellknown vs2019 and vs2022 client application ids to allow application deployments with aad
- Update documentation from AAD -> Entra
- Removed unreferenced file examples.txt
- Add param() to common.ps1 for consistency
- Refactor variable use between scripts
- Make $global:ConfigObj a static variable for scripts and not use it for determining auth
- Add additional parameters to get-REST* for clarification / readability
- Fix transcript logging
- Add optional switch to configure Visual Studio access for MSAL authentication to resolve error: AADSTS65001: The user or administrator has not consented to use the application with ID '04f0c124-f2bc-4f59-8241-bf6df9866bbd' named 'Visual Studio'.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]

```

* Test the code
create test ms graph app registration with client secret in entra
use newly created clientid and secret with test-aad-setup.ps1 script as shown:
.\test-aad-setup.ps1 -resourceGroupName sftestcluster -AddVisualStudioAccess -MGClientSecret 'xxx' -MGClientId xxx
```
```

## What to Check
Verify that the following are valid
* ...
Check that 'ServiceFabricCluster' and 'ServiceFabricClusterNativeClient' app registrations are created with VS client ids granted permissions in entra

## Other Information
<!-- Add any other helpful information that may be needed here. -->